### PR TITLE
Call postDefine in finally

### DIFF
--- a/src/main/java/org/jboss/modules/ModuleClassLoader.java
+++ b/src/main/java/org/jboss/modules/ModuleClassLoader.java
@@ -258,12 +258,16 @@ public class ModuleClassLoader extends ConcurrentClassLoader {
         catch (Throwable th) {
             throw new ClassNotFoundException("Failed to preDefine class: " + className, th);
         }
-        final Class<?> clazz = defineClass(className, classSpec);
-        try{
-            postDefine(classSpec, clazz);
-        }
-        catch (Throwable th) {
-            throw new ClassNotFoundException("Failed to postDefine class: " + className, th);
+        Class<?> clazz = null;
+        try {
+            clazz = defineClass(className, classSpec);
+        } finally {
+            try{
+                postDefine(classSpec, clazz);
+            }
+            catch (Throwable th) {
+                throw new ClassNotFoundException("Failed to postDefine class: " + className, th);
+            }
         }
         if (resolve) {
             resolveClass(clazz);


### PR DESCRIPTION
If postDefine is not in finally, we might not properly "cleanup" from whatever preDefine is doing.
