### PR TITLE
Fixed error in ChildPathFilter.equals()

### DIFF
--- a/src/main/java/org/jboss/modules/filter/ChildPathFilter.java
+++ b/src/main/java/org/jboss/modules/filter/ChildPathFilter.java
@@ -38,7 +38,7 @@ final class ChildPathFilter implements PathFilter {
     }
 
     public boolean equals(final Object obj) {
-        return obj instanceof EqualsPathFilter && equals((ChildPathFilter) obj);
+        return obj instanceof ChildPathFilter && equals((ChildPathFilter) obj);
     }
 
     public boolean equals(final ChildPathFilter obj) {


### PR DESCRIPTION
The equals() method checked for a wrong type of the argument which in the end leads to dependencies not being matched in JBoss 7 that lead to 100% CPU problems.
