### PR TITLE
AS7-3512 ignore logmodule for backwards compatbility

### DIFF
--- a/src/main/java/org/jboss/modules/Main.java
+++ b/src/main/java/org/jboss/modules/Main.java
@@ -194,7 +194,10 @@ public final class Main {
                             System.exit(1);
                         }
                         classDefined = true;
-                    } else {
+                    } else if ("-logmodule".equals(arg)) {
+			String ignored = args[++i];
+			System.out.println("Warning: ignoring -logmodule argument."); 
+		    } else {
                         System.err.printf("Invalid option '%s'\n", arg);
                         usage();
                         System.exit(1);


### PR DESCRIPTION
implemented ignore of -logmodule by using same logic as was in previous Main.java (i.e. argv[i++])

Prints out "Warning: ignoring -logmodule"

Tested to work with jboss tools startup which works with AS7.0-AS7.1CR1
