### PR TITLE
Adds trace log when preload dependency fails

### DIFF
--- a/src/main/java/org/jboss/modules/Module.java
+++ b/src/main/java/org/jboss/modules/Module.java
@@ -846,7 +846,7 @@ public final class Module {
                     if (moduleDependency.isOptional()) {
                         continue;
                     } else {
-                        log.trace("Failed preloading dependency %s of module %s", moduleDependency.getIdentifier(), getIdentifier());
+                        log.trace("Module %s, dependency preload failed: %s", getIdentifier(), ex);
                         throw ex;
                     }
                 }
@@ -983,7 +983,7 @@ public final class Module {
                         if (moduleDependency.isOptional()) {
                             continue;
                         } else {
-                            log.trace("Failed preloading dependency %s of module %s", moduleDependency.getIdentifier(), getIdentifier());
+                            log.trace("Module %s, dependency preload failed: %s", getIdentifier(), ex);
                             throw ex;
                         }
                     }


### PR DESCRIPTION
When moduleLoader fails to preload a dependency, due to a misspelled dependency name for instance, jboss-modules hangs (until timeout) without giving any indication.

Actually this log should perhaps be a warning, but that level is not available for ModuleLogger.
