### PR TITLE
Use loadClass rather than loadClassLocal

### DIFF
--- a/src/main/java/org/jboss/modules/security/ModularPermissionFactory.java
+++ b/src/main/java/org/jboss/modules/security/ModularPermissionFactory.java
@@ -78,7 +78,7 @@ public final class ModularPermissionFactory implements PermissionFactory {
             }
             try {
                 final Module module = moduleLoader.loadModule(moduleIdentifier);
-                final Class<? extends Permission> permissionClass = module.getClassLoader().loadClassLocal(className, true).asSubclass(Permission.class);
+                final Class<? extends Permission> permissionClass = module.getClassLoader().loadClass(className, true).asSubclass(Permission.class);
                 final Constructor<? extends Permission> constructor = permissionClass.getConstructor(String.class, String.class);
                 return instance = constructor.newInstance(targetName, permissionActions);
             } catch (Throwable t) {


### PR DESCRIPTION
As this currently stands it does not work with permissions.xml if you reference permission classes that are not local to the module. 
