### PR TITLE
Avoid potential NullPointerException in ModulesPolicy getPermissions() and implies()

### DIFF
--- a/src/main/java/org/jboss/modules/ModulesPolicy.java
+++ b/src/main/java/org/jboss/modules/ModulesPolicy.java
@@ -64,11 +64,19 @@ final class ModulesPolicy extends Policy {
     }
 
     public PermissionCollection getPermissions(final ProtectionDomain domain) {
-        return domain.getCodeSource().equals(ourCodeSource) ? getAllPermission() : policy.getPermissions(domain);
+        CodeSource codeSource = domain.getCodeSource();
+        if (codeSource != null)
+            return codeSource.equals(ourCodeSource) ? getAllPermission() : policy.getPermissions(domain);
+        else
+            return policy.getPermissions(domain);
     }
 
     public boolean implies(final ProtectionDomain domain, final Permission permission) {
-        return domain.getCodeSource().equals(ourCodeSource) || policy.implies(domain, permission);
+        CodeSource codeSource = domain.getCodeSource();
+        if (codeSource != null)
+            return codeSource.equals(ourCodeSource) || policy.implies(domain, permission);
+        else
+            return policy.implies(domain, permission);
     }
 
     public void refresh() {


### PR DESCRIPTION
Issue is described in https://bugzilla.redhat.com/show_bug.cgi?id=1122580
Although I can not reproduce same error in EAP6 with IBM JDK6, it should avoid potential NullPointException as the return of CodeSource in ProtectionDomain may be null.
