### PR TITLE
Add 'org.jcp.xml.dsig.internal' as system package.

### DIFF
--- a/src/main/java/org/jboss/modules/Module.java
+++ b/src/main/java/org/jboss/modules/Module.java
@@ -88,6 +88,7 @@ public final class Module {
         final List<String> list = new ArrayList<String>();
         list.add("java.");
         list.add("sun.reflect.");
+        list.add("org.jcp.xml.dsig.internal");
         list.add("__redirected.");
         if (pkgsString != null) {
             int i;


### PR DESCRIPTION
1. This package is included in both jdk7 and jdk8.
2. Use package will be used as a typical jsr105 usage, such as 
```
        String providerName = System.getProperty("jsr105Provider", "org.jcp.xml.dsig.internal.dom.XMLDSigRI");
        XMLSignatureFactory fac =
            XMLSignatureFactory.getInstance("DOM", (Provider) Class.forName(providerName).newInstance());
```