### PR TITLE
throw new IllegalArgumentException("name is empty") when the className is empty

### DIFF
--- a/src/main/java/org/jboss/modules/ConcurrentClassLoader.java
+++ b/src/main/java/org/jboss/modules/ConcurrentClassLoader.java
@@ -340,6 +340,9 @@ public abstract class ConcurrentClassLoader extends ClassLoader {
         if (className == null) {
             throw new IllegalArgumentException("name is null");
         }
+        if (className.length() == 0) {
+            throw new IllegalArgumentException("name is empty");
+        }
         for (String s : Module.systemPackages) {
             if (className.startsWith(s)) {
                 return definingLoader != null ? definingLoader.loadClass(className) : findSystemClass(className);


### PR DESCRIPTION
java.lang.StringIndexOutOfBoundsException: String index out of range: 0
        at java.lang.String.charAt(String.java:658) [rt.jar:1.7.0_55]
        at org.jboss.modules.ConcurrentClassLoader.performLoadClassUnchecked(ConcurrentClassLoader.java:436) [jboss-modules.jar:1.2.2.Final-redhat-1]
        at org.jboss.modules.ConcurrentClassLoader.performLoadClassChecked(ConcurrentClassLoader.java:432) [jboss-modules.jar:1.2.2.Final-redhat-1]
        at org.jboss.modules.ConcurrentClassLoader.performLoadClass(ConcurrentClassLoader.java:374) [jboss-modules.jar:1.2.2.Final-redhat-1]