### PR TITLE
Revert "Remove JAXP redirect hacks, as JAXP 1.6 that is part of JDK8 …

### DIFF
--- a/src/main/java/__redirected/__DatatypeFactory.java
+++ b/src/main/java/__redirected/__DatatypeFactory.java
@@ -1,0 +1,213 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.GregorianCalendar;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.Duration;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+
+/**
+ * A redirecting DatatypeFactory
+ *
+ * @author Jason T. Greene
+ */
+@SuppressWarnings("unchecked")
+public final class __DatatypeFactory extends DatatypeFactory {
+    private static final Constructor<? extends DatatypeFactory> PLATFORM_FACTORY;
+    private static volatile Constructor<? extends DatatypeFactory> DEFAULT_FACTORY;
+
+    static {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+
+        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
+        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
+        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
+        // Thus, the class can not be found.
+        //
+        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
+        // the environment's TCCL
+        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
+        try {
+            if (System.getProperty(DatatypeFactory.class.getName(), "").equals(__DatatypeFactory.class.getName())) {
+                System.clearProperty(DatatypeFactory.class.getName());
+            }
+            DatatypeFactory factory = DatatypeFactory.newInstance();
+            try {
+                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+            System.setProperty(DatatypeFactory.class.getName(), __DatatypeFactory.class.getName());
+        } catch (DatatypeConfigurationException e) {
+            throw new IllegalArgumentException("Problem configuring DatatypeFactory", e);
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
+        Class<? extends DatatypeFactory> clazz = __RedirectedUtils.loadProvider(id, DatatypeFactory.class, loader);
+        if (clazz != null) {
+            try {
+                DEFAULT_FACTORY = clazz.getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+        }
+    }
+
+    public static void restorePlatformFactory() {
+        DEFAULT_FACTORY = PLATFORM_FACTORY;
+    }
+
+    /**
+     * Init method.
+     */
+    public static void init() {}
+
+    /**
+     * Construct a new instance.
+     */
+    public __DatatypeFactory() {
+        Constructor<? extends DatatypeFactory> factory = DEFAULT_FACTORY;
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try {
+            if (loader != null) {
+                Class<? extends DatatypeFactory> provider = __RedirectedUtils.loadProvider(DatatypeFactory.class, loader);
+                if (provider != null)
+                    factory = provider.getConstructor();
+            }
+
+            actual = factory.newInstance();
+        } catch (InstantiationException e) {
+            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
+        } catch (IllegalAccessException e) {
+            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
+        } catch (InvocationTargetException e) {
+            throw __RedirectedUtils.rethrowCause(e);
+        } catch (NoSuchMethodException e) {
+            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        }
+    }
+
+    private final DatatypeFactory actual;
+
+    public Duration newDuration(String lexicalRepresentation) {
+        return actual.newDuration(lexicalRepresentation);
+    }
+
+    public String toString() {
+        return actual.toString();
+    }
+
+    public Duration newDuration(long durationInMilliSeconds) {
+        return actual.newDuration(durationInMilliSeconds);
+    }
+
+    public Duration newDuration(boolean isPositive, BigInteger years, BigInteger months, BigInteger days, BigInteger hours,
+            BigInteger minutes, BigDecimal seconds) {
+        return actual.newDuration(isPositive, years, months, days, hours, minutes, seconds);
+    }
+
+    public Duration newDuration(boolean isPositive, int years, int months, int days, int hours, int minutes, int seconds) {
+        return actual.newDuration(isPositive, years, months, days, hours, minutes, seconds);
+    }
+
+    public Duration newDurationDayTime(String lexicalRepresentation) {
+        return actual.newDurationDayTime(lexicalRepresentation);
+    }
+
+    public Duration newDurationDayTime(long durationInMilliseconds) {
+        return actual.newDurationDayTime(durationInMilliseconds);
+    }
+
+    public Duration newDurationDayTime(boolean isPositive, BigInteger day, BigInteger hour, BigInteger minute, BigInteger second) {
+        return actual.newDurationDayTime(isPositive, day, hour, minute, second);
+    }
+
+    public Duration newDurationDayTime(boolean isPositive, int day, int hour, int minute, int second) {
+        return actual.newDurationDayTime(isPositive, day, hour, minute, second);
+    }
+
+    public Duration newDurationYearMonth(String lexicalRepresentation) {
+        return actual.newDurationYearMonth(lexicalRepresentation);
+    }
+
+    public Duration newDurationYearMonth(long durationInMilliseconds) {
+        return actual.newDurationYearMonth(durationInMilliseconds);
+    }
+
+    public Duration newDurationYearMonth(boolean isPositive, BigInteger year, BigInteger month) {
+        return actual.newDurationYearMonth(isPositive, year, month);
+    }
+
+    public Duration newDurationYearMonth(boolean isPositive, int year, int month) {
+        return actual.newDurationYearMonth(isPositive, year, month);
+    }
+
+    public XMLGregorianCalendar newXMLGregorianCalendar() {
+        return actual.newXMLGregorianCalendar();
+    }
+
+    public XMLGregorianCalendar newXMLGregorianCalendar(String lexicalRepresentation) {
+        return actual.newXMLGregorianCalendar(lexicalRepresentation);
+    }
+
+    public XMLGregorianCalendar newXMLGregorianCalendar(GregorianCalendar cal) {
+        return actual.newXMLGregorianCalendar(cal);
+    }
+
+    public XMLGregorianCalendar newXMLGregorianCalendar(BigInteger year, int month, int day, int hour, int minute, int second,
+            BigDecimal fractionalSecond, int timezone) {
+        return actual.newXMLGregorianCalendar(year, month, day, hour, minute, second, fractionalSecond, timezone);
+    }
+
+    public XMLGregorianCalendar newXMLGregorianCalendar(int year, int month, int day, int hour, int minute, int second,
+            int millisecond, int timezone) {
+        return actual.newXMLGregorianCalendar(year, month, day, hour, minute, second, millisecond, timezone);
+    }
+
+    public XMLGregorianCalendar newXMLGregorianCalendarDate(int year, int month, int day, int timezone) {
+        return actual.newXMLGregorianCalendarDate(year, month, day, timezone);
+    }
+
+    public XMLGregorianCalendar newXMLGregorianCalendarTime(int hours, int minutes, int seconds, int timezone) {
+        return actual.newXMLGregorianCalendarTime(hours, minutes, seconds, timezone);
+    }
+
+    public XMLGregorianCalendar newXMLGregorianCalendarTime(int hours, int minutes, int seconds, BigDecimal fractionalSecond,
+            int timezone) {
+        return actual.newXMLGregorianCalendarTime(hours, minutes, seconds, fractionalSecond, timezone);
+    }
+
+    public XMLGregorianCalendar newXMLGregorianCalendarTime(int hours, int minutes, int seconds, int milliseconds, int timezone) {
+        return actual.newXMLGregorianCalendarTime(hours, minutes, seconds, milliseconds, timezone);
+    }
+}

--- a/src/main/java/__redirected/__DocumentBuilderFactory.java
+++ b/src/main/java/__redirected/__DocumentBuilderFactory.java
@@ -1,0 +1,200 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.validation.Schema;
+
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+
+/**
+ * A redirecting DocumentBuilderFactory
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author Jason T. Greene
+ */
+public final class __DocumentBuilderFactory extends DocumentBuilderFactory {
+    private static final Constructor<? extends DocumentBuilderFactory> PLATFORM_FACTORY;
+    private static volatile Constructor<? extends DocumentBuilderFactory> DEFAULT_FACTORY;
+
+    static {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+
+        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
+        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
+        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
+        // Thus, the class can not be found.
+        //
+        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
+        // the environment's TCCL
+        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
+        try {
+            if (System.getProperty(DocumentBuilderFactory.class.getName(), "").equals(__DocumentBuilderFactory.class.getName())) {
+                System.clearProperty(DocumentBuilderFactory.class.getName());
+            }
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            try {
+                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+            System.setProperty(DocumentBuilderFactory.class.getName(), __DocumentBuilderFactory.class.getName());
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    /**
+     * Init method.
+     */
+    public static void init() {}
+
+    public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
+        Class<? extends DocumentBuilderFactory> clazz = __RedirectedUtils.loadProvider(id, DocumentBuilderFactory.class, loader);
+        if (clazz != null) {
+            try {
+                DEFAULT_FACTORY = clazz.getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+        }
+    }
+
+    public static void restorePlatformFactory() {
+        DEFAULT_FACTORY = PLATFORM_FACTORY;
+    }
+
+    /**
+     * Construct a new instance.
+     */
+    public __DocumentBuilderFactory() {
+        Constructor<? extends DocumentBuilderFactory> factory = DEFAULT_FACTORY;
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try {
+            if (loader != null) {
+                Class<? extends DocumentBuilderFactory> provider = __RedirectedUtils.loadProvider(DocumentBuilderFactory.class, loader);
+                if (provider != null)
+                    factory = provider.getConstructor();
+            }
+
+            actual = factory.newInstance();
+        } catch (InstantiationException e) {
+            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
+        } catch (IllegalAccessException e) {
+            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
+        } catch (InvocationTargetException e) {
+            throw __RedirectedUtils.rethrowCause(e);
+        } catch (NoSuchMethodException e) {
+            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        }
+    }
+
+    private final DocumentBuilderFactory actual;
+
+    public DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
+        return actual.newDocumentBuilder();
+    }
+
+    public void setNamespaceAware(final boolean awareness) {
+        actual.setNamespaceAware(awareness);
+    }
+
+    public void setValidating(final boolean validating) {
+        actual.setValidating(validating);
+    }
+
+    public void setIgnoringElementContentWhitespace(final boolean whitespace) {
+        actual.setIgnoringElementContentWhitespace(whitespace);
+    }
+
+    public void setExpandEntityReferences(final boolean expandEntityRef) {
+        actual.setExpandEntityReferences(expandEntityRef);
+    }
+
+    public void setIgnoringComments(final boolean ignoreComments) {
+        actual.setIgnoringComments(ignoreComments);
+    }
+
+    public void setCoalescing(final boolean coalescing) {
+        actual.setCoalescing(coalescing);
+    }
+
+    public boolean isNamespaceAware() {
+        return actual.isNamespaceAware();
+    }
+
+    public boolean isValidating() {
+        return actual.isValidating();
+    }
+
+    public boolean isIgnoringElementContentWhitespace() {
+        return actual.isIgnoringElementContentWhitespace();
+    }
+
+    public boolean isExpandEntityReferences() {
+        return actual.isExpandEntityReferences();
+    }
+
+    public boolean isIgnoringComments() {
+        return actual.isIgnoringComments();
+    }
+
+    public boolean isCoalescing() {
+        return actual.isCoalescing();
+    }
+
+    public void setAttribute(final String name, final Object value) throws IllegalArgumentException {
+        actual.setAttribute(name, value);
+    }
+
+    public Object getAttribute(final String name) throws IllegalArgumentException {
+        return actual.getAttribute(name);
+    }
+
+    public void setFeature(final String name, final boolean value) throws ParserConfigurationException {
+        actual.setFeature(name, value);
+    }
+
+    public boolean getFeature(final String name) throws ParserConfigurationException {
+        return actual.getFeature(name);
+    }
+
+    public Schema getSchema() {
+        return actual.getSchema();
+    }
+
+    public void setSchema(final Schema schema) {
+        actual.setSchema(schema);
+    }
+
+    public void setXIncludeAware(final boolean state) {
+        actual.setXIncludeAware(state);
+    }
+
+    public boolean isXIncludeAware() {
+        return actual.isXIncludeAware();
+    }
+}

--- a/src/main/java/__redirected/__JAXPRedirected.java
+++ b/src/main/java/__redirected/__JAXPRedirected.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package __redirected;
+
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+
+/**
+ * Executes common operations against ALL JAXP redirection classes.
+ *
+ * @author Jason T. Greene
+ */
+public class __JAXPRedirected {
+
+    /**
+     * Change all provided factories to the ones contained in the
+     * specified module using the standard META-INF/services lookup
+     * pattern.
+     *
+     * @param id the id for the jaxp module
+     * @param loader the loader containing the jaxp module
+     */
+    public static void changeAll(ModuleIdentifier id, ModuleLoader loader) {
+        __DocumentBuilderFactory.changeDefaultFactory(id, loader);
+        __SAXParserFactory.changeDefaultFactory(id, loader);
+        __TransformerFactory.changeDefaultFactory(id, loader);
+        __XPathFactory.changeDefaultFactory(id, loader);
+        __XMLEventFactory.changeDefaultFactory(id, loader);
+        __XMLInputFactory.changeDefaultFactory(id, loader);
+        __XMLOutputFactory.changeDefaultFactory(id, loader);
+        __DatatypeFactory.changeDefaultFactory(id, loader);
+        __SchemaFactory.changeDefaultFactory(id, loader);
+        __XMLReaderFactory.changeDefaultFactory(id, loader);
+    }
+
+    /**
+     * Restores all JAXP factories to the ones contained in the JDK
+     * system classpath.
+     */
+    public static void restorePlatformFactory() {
+        __DocumentBuilderFactory.restorePlatformFactory();
+        __SAXParserFactory.restorePlatformFactory();
+        __TransformerFactory.restorePlatformFactory();
+        __XPathFactory.restorePlatformFactory();
+        __XMLEventFactory.restorePlatformFactory();
+        __XMLInputFactory.restorePlatformFactory();
+        __XMLOutputFactory.restorePlatformFactory();
+        __DatatypeFactory.restorePlatformFactory();
+        __SchemaFactory.restorePlatformFactory();
+        __XMLReaderFactory.restorePlatformFactory();
+    }
+
+    /**
+     * Initializes the JAXP redirection system.
+     */
+    public static void initAll() {
+        __DocumentBuilderFactory.init();
+        __SAXParserFactory.init();
+        __TransformerFactory.init();
+        __XPathFactory.init();
+        __XMLEventFactory.init();
+        __XMLInputFactory.init();
+        __XMLOutputFactory.init();
+        __DatatypeFactory.init();
+        __SchemaFactory.init();
+        __XMLReaderFactory.init();
+    }
+}

--- a/src/main/java/__redirected/__RedirectedUtils.java
+++ b/src/main/java/__redirected/__RedirectedUtils.java
@@ -1,0 +1,186 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleClassLoader;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoadException;
+import org.jboss.modules.ModuleLoader;
+import org.jboss.modules.log.ModuleLogger;
+
+/**
+ * Common utilities for redirected factories
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @authore Jason T. Greene
+ */
+public final class __RedirectedUtils {
+
+    static ModuleLogger getModuleLogger() {
+        final SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            return AccessController.doPrivileged(new PrivilegedAction<ModuleLogger>() {
+                public ModuleLogger run() {
+                    return Module.getModuleLogger();
+                }
+            });
+        } else {
+            return Module.getModuleLogger();
+        }
+    }
+
+    static RuntimeException rethrowCause(Throwable t) throws Error {
+        try {
+            throw t.getCause();
+        } catch (Error e) {
+            throw e;
+        } catch (RuntimeException re) {
+            return re;
+        } catch (Throwable throwable) {
+            return new UndeclaredThrowableException(throwable);
+        }
+    }
+
+    static <E extends Throwable> E wrapped(E e, Throwable orig) {
+        Throwable cause = orig.getCause();
+        if (cause != null) {
+            e.initCause(cause);
+        }
+        e.setStackTrace(orig.getStackTrace());
+        return e;
+    }
+
+    static <T> Class<? extends T> loadProvider(ModuleIdentifier id, Class<T> intf, ModuleLoader moduleLoader) {
+        return loadProvider(id, intf, moduleLoader, null);
+    }
+
+    static <T> Class<? extends T> loadProvider(ModuleIdentifier id, Class<T> intf, ModuleLoader moduleLoader, String name) {
+        Module module;
+        try {
+            module = moduleLoader.loadModule(id);
+        } catch (ModuleLoadException e) {
+            getModuleLogger().providerUnloadable(id.toString(), null);
+            return null;
+        }
+
+        ModuleClassLoader classLoader = module.getClassLoader();
+        return loadProvider(intf, classLoader, name);
+    }
+
+    static <T> Class<? extends T> loadProvider(Class<T> intf, ClassLoader classLoader) {
+        return loadProvider(intf, classLoader, null);
+    }
+
+    static <T> Class<? extends T> loadProvider(Class<T> intf, ClassLoader classLoader, String name) {
+        List<String> names = findProviderClassNames(intf, classLoader, name);
+
+        if (names.isEmpty()) {
+            getModuleLogger().providerUnloadable("Not found", classLoader);
+            return null;
+        }
+
+        String clazzName = names.get(0);
+        try {
+            return classLoader.loadClass(clazzName).asSubclass(intf);
+        } catch (Exception ignore) {
+            getModuleLogger().providerUnloadable(clazzName, classLoader);
+            return null;
+        }
+    }
+
+    static <T> List<Class<? extends T>> loadProviders(Class<T> intf, ClassLoader classLoader) {
+        return loadProviders(intf, classLoader, null);
+    }
+
+    static <T> List<Class<? extends T>> loadProviders(Class<T> intf, ClassLoader classLoader, String name) {
+        List<String> names = findProviderClassNames(intf, classLoader, name);
+
+        if (names.size() < 1) {
+            getModuleLogger().providerUnloadable("Not found", classLoader);
+            return Collections.emptyList();
+        }
+
+        List<Class<? extends T>> classes = new ArrayList<Class<? extends T>>();
+
+        for (String className : names) {
+            try {
+                classes.add(classLoader.loadClass(className).asSubclass(intf));
+            } catch (Exception ignore) {
+                getModuleLogger().providerUnloadable(className, classLoader);
+            }
+        }
+
+        return classes;
+    }
+
+    static <T> List<String> findProviderClassNames(Class<T> intf, ClassLoader loader, String name) {
+        if (name == null)
+            name = intf.getName();
+
+        final InputStream stream = loader.getResourceAsStream("META-INF/services/" + name);
+        if (stream == null)
+            return Collections.emptyList();
+
+
+        List<String> list = new ArrayList<String>();
+        try {
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+
+            String line;
+            while ((line = readLine(reader)) != null) {
+                final int i = line.indexOf('#');
+                if (i != -1) {
+                    line = line.substring(0, i);
+                }
+                line = line.trim();
+                if (line.length() == 0)
+                    continue;
+
+                list.add(line);
+            }
+        } finally {
+            try {
+                stream.close();
+            } catch (IOException ignored) {
+            }
+        }
+        return list;
+    }
+
+    private static String readLine(final BufferedReader reader) {
+        try {
+            return reader.readLine();
+        } catch (IOException ignore) {
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/__redirected/__SAXParserFactory.java
+++ b/src/main/java/__redirected/__SAXParserFactory.java
@@ -1,0 +1,163 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.validation.Schema;
+
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+
+/**
+ * A redirected SAXParserFactory
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @authore Jason T. Greene
+ */
+public final class __SAXParserFactory extends SAXParserFactory {
+    private static final Constructor<? extends SAXParserFactory> PLATFORM_FACTORY;
+    private static volatile Constructor<? extends SAXParserFactory> DEFAULT_FACTORY;
+
+    static {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+
+        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
+        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
+        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
+        // Thus, the class can not be found.
+        //
+        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
+        // the environment's TCCL
+        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
+        try {
+            if (System.getProperty(SAXParserFactory.class.getName(), "").equals(__SAXParserFactory.class.getName())) {
+                System.clearProperty(SAXParserFactory.class.getName());
+            }
+            SAXParserFactory factory = SAXParserFactory.newInstance();
+            try {
+               DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+            System.setProperty(SAXParserFactory.class.getName(), __SAXParserFactory.class.getName());
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
+        Class<? extends SAXParserFactory> clazz = __RedirectedUtils.loadProvider(id, SAXParserFactory.class, loader);
+        if (clazz != null) {
+            try {
+                DEFAULT_FACTORY = clazz.getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+        }
+    }
+
+    public static void restorePlatformFactory() {
+        DEFAULT_FACTORY = PLATFORM_FACTORY;
+    }
+
+    /**
+     * Init method.
+     */
+    public static void init() {}
+
+    /**
+     * Construct a new instance.
+     */
+    public __SAXParserFactory() {
+        Constructor<? extends SAXParserFactory> factory = DEFAULT_FACTORY;
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try {
+            if (loader != null) {
+                Class<? extends SAXParserFactory> provider = __RedirectedUtils.loadProvider(SAXParserFactory.class, loader);
+                if (provider != null)
+                    factory = provider.getConstructor();
+            }
+
+            actual = factory.newInstance();
+        } catch (InstantiationException e) {
+            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
+        } catch (IllegalAccessException e) {
+            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
+        } catch (InvocationTargetException e) {
+            throw __RedirectedUtils.rethrowCause(e);
+        } catch (NoSuchMethodException e) {
+            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        }
+    }
+
+    private final SAXParserFactory actual;
+
+    public SAXParser newSAXParser() throws ParserConfigurationException, SAXException {
+        return actual.newSAXParser();
+    }
+
+    public void setNamespaceAware(final boolean awareness) {
+        actual.setNamespaceAware(awareness);
+    }
+
+    public void setValidating(final boolean validating) {
+        actual.setValidating(validating);
+    }
+
+    public boolean isNamespaceAware() {
+        return actual.isNamespaceAware();
+    }
+
+    public boolean isValidating() {
+        return actual.isValidating();
+    }
+
+    public void setFeature(final String name, final boolean value) throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+        actual.setFeature(name, value);
+    }
+
+    public boolean getFeature(final String name) throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+        return actual.getFeature(name);
+    }
+
+    public Schema getSchema() {
+        return actual.getSchema();
+    }
+
+    public void setSchema(final Schema schema) {
+        actual.setSchema(schema);
+    }
+
+    public void setXIncludeAware(final boolean state) {
+        actual.setXIncludeAware(state);
+    }
+
+    public boolean isXIncludeAware() {
+        return actual.isXIncludeAware();
+    }
+}

--- a/src/main/java/__redirected/__SchemaFactory.java
+++ b/src/main/java/__redirected/__SchemaFactory.java
@@ -1,0 +1,185 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.util.List;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.Source;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+import org.w3c.dom.ls.LSResourceResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+
+/**
+ * A redirected SchemaFactory
+ *
+ * @author Jason T. Greene
+ */
+public final class __SchemaFactory extends SchemaFactory {
+    private static final Constructor<? extends SchemaFactory> PLATFORM_FACTORY;
+    private static volatile Constructor<? extends SchemaFactory> DEFAULT_FACTORY;
+
+    static {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+
+        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
+        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
+        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
+        // Thus, the class can not be found.
+        //
+        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
+        // the environment's TCCL
+        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
+        try {
+            if (System.getProperty(SchemaFactory.class.getName(), "").equals(__SchemaFactory.class.getName())) {
+                System.clearProperty(SchemaFactory.class.getName());
+            }
+            SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            try {
+                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+            System.setProperty(SchemaFactory.class.getName() + ":" + XMLConstants.W3C_XML_SCHEMA_NS_URI, __SchemaFactory.class.getName());
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
+        Class<? extends SchemaFactory> clazz = __RedirectedUtils.loadProvider(id, SchemaFactory.class, loader);
+        if (clazz != null) {
+            try {
+                DEFAULT_FACTORY = clazz.getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+        }
+    }
+
+    public static void restorePlatformFactory() {
+        DEFAULT_FACTORY = PLATFORM_FACTORY;
+    }
+
+    /**
+     * Init method.
+     */
+    public static void init() {}
+
+    /**
+     * Construct a new instance.
+     */
+    public __SchemaFactory() {
+        Constructor<? extends SchemaFactory> factory = DEFAULT_FACTORY;
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        SchemaFactory foundInstance = null;
+        try {
+            if (loader != null) {
+                List<Class<? extends SchemaFactory>> providers = __RedirectedUtils.loadProviders(SchemaFactory.class, loader);
+                for (Class<? extends SchemaFactory> provider : providers) {
+                    SchemaFactory instance = provider.newInstance();
+                    if (instance.isSchemaLanguageSupported(XMLConstants.W3C_XML_SCHEMA_NS_URI)) {
+                        foundInstance = instance;
+                        break;
+                    }
+                }
+            }
+
+            actual = foundInstance != null ? foundInstance : factory.newInstance();
+
+        } catch (InstantiationException e) {
+            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
+        } catch (IllegalAccessException e) {
+            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
+        } catch (InvocationTargetException e) {
+            throw __RedirectedUtils.rethrowCause(e);
+        }
+    }
+
+
+    private final SchemaFactory actual;
+
+    public boolean isSchemaLanguageSupported(String objectModel) {
+        return actual.isSchemaLanguageSupported(objectModel);
+    }
+
+    public boolean getFeature(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
+        return actual.getFeature(name);
+    }
+
+    public void setFeature(String name, boolean value) throws SAXNotSupportedException, SAXNotRecognizedException {
+        actual.setFeature(name, value);
+    }
+
+    public void setProperty(String name, Object object) throws SAXNotRecognizedException, SAXNotSupportedException {
+        actual.setProperty(name, object);
+    }
+
+    public Object getProperty(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
+        return actual.getProperty(name);
+    }
+
+    public void setErrorHandler(ErrorHandler errorHandler) {
+        actual.setErrorHandler(errorHandler);
+    }
+
+    public ErrorHandler getErrorHandler() {
+        return actual.getErrorHandler();
+    }
+
+    public void setResourceResolver(LSResourceResolver resourceResolver) {
+        actual.setResourceResolver(resourceResolver);
+    }
+
+    public LSResourceResolver getResourceResolver() {
+        return actual.getResourceResolver();
+    }
+
+    public Schema newSchema(Source schema) throws SAXException {
+        return actual.newSchema(schema);
+    }
+
+    public Schema newSchema(File schema) throws SAXException {
+        return actual.newSchema(schema);
+    }
+
+    public Schema newSchema(URL schema) throws SAXException {
+        return actual.newSchema(schema);
+    }
+
+    public Schema newSchema(Source[] schemas) throws SAXException {
+        return actual.newSchema(schemas);
+    }
+
+    public Schema newSchema() throws SAXException {
+        return actual.newSchema();
+    }
+}

--- a/src/main/java/__redirected/__TransformerFactory.java
+++ b/src/main/java/__redirected/__TransformerFactory.java
@@ -1,0 +1,215 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.xml.transform.ErrorListener;
+import javax.xml.transform.Source;
+import javax.xml.transform.Templates;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.URIResolver;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TemplatesHandler;
+import javax.xml.transform.sax.TransformerHandler;
+
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+import org.xml.sax.XMLFilter;
+
+/**
+ * A redirected TransformerFactory
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author Jason T. Greene
+ */
+public final class __TransformerFactory extends SAXTransformerFactory {
+    private static final Constructor<? extends TransformerFactory> PLATFORM_FACTORY;
+    private static volatile Constructor<? extends TransformerFactory> DEFAULT_FACTORY;
+
+    static {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+
+        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
+        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
+        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
+        // Thus, the class can not be found.
+        //
+        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
+        // the environment's TCCL
+        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
+        try {
+            if (System.getProperty(TransformerFactory.class.getName(), "").equals(__TransformerFactory.class.getName())) {
+                System.clearProperty(TransformerFactory.class.getName());
+            }
+            TransformerFactory factory = TransformerFactory.newInstance();
+            try {
+                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+            System.setProperty(TransformerFactory.class.getName(), __TransformerFactory.class.getName());
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
+        Class<? extends TransformerFactory> clazz = __RedirectedUtils.loadProvider(id, TransformerFactory.class, loader);
+        if (clazz != null) {
+            try {
+                DEFAULT_FACTORY = clazz.getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+        }
+    }
+
+    public static void restorePlatformFactory() {
+        DEFAULT_FACTORY = PLATFORM_FACTORY;
+    }
+
+    /**
+     * Init method.
+     */
+    public static void init() {}
+
+    /**
+     * Construct a new instance.
+     */
+    public __TransformerFactory() {
+        Constructor<? extends TransformerFactory> factory = DEFAULT_FACTORY;
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try {
+            if (loader != null) {
+                Class<? extends TransformerFactory> provider = __RedirectedUtils.loadProvider(TransformerFactory.class, loader);
+                if (provider != null)
+                    factory = provider.getConstructor();
+            }
+
+            actual = factory.newInstance();
+            saxtual = (actual instanceof SAXTransformerFactory) ? (SAXTransformerFactory)actual : null;
+
+        } catch (InstantiationException e) {
+            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
+        } catch (IllegalAccessException e) {
+            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
+        } catch (InvocationTargetException e) {
+            throw __RedirectedUtils.rethrowCause(e);
+        } catch (NoSuchMethodException e) {
+            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        }
+    }
+
+    private final TransformerFactory actual;
+    private final SAXTransformerFactory saxtual; // Snicker
+
+    public Transformer newTransformer(Source source) throws TransformerConfigurationException {
+        return actual.newTransformer(source);
+    }
+
+    public Transformer newTransformer() throws TransformerConfigurationException {
+        return actual.newTransformer();
+    }
+
+    public Templates newTemplates(Source source) throws TransformerConfigurationException {
+        return actual.newTemplates(source);
+    }
+
+    public String toString() {
+        return actual.toString();
+    }
+
+    public Source getAssociatedStylesheet(Source source, String media, String title, String charset)
+            throws TransformerConfigurationException {
+        return actual.getAssociatedStylesheet(source, media, title, charset);
+    }
+
+    public void setURIResolver(URIResolver resolver) {
+        actual.setURIResolver(resolver);
+    }
+
+    public URIResolver getURIResolver() {
+        return actual.getURIResolver();
+    }
+
+    public void setFeature(String name, boolean value) throws TransformerConfigurationException {
+        actual.setFeature(name, value);
+    }
+
+    public boolean getFeature(String name) {
+        return actual.getFeature(name);
+    }
+
+    public void setAttribute(String name, Object value) {
+        actual.setAttribute(name, value);
+    }
+
+    public Object getAttribute(String name) {
+        return actual.getAttribute(name);
+    }
+
+    public void setErrorListener(ErrorListener listener) {
+        actual.setErrorListener(listener);
+    }
+
+    public ErrorListener getErrorListener() {
+        return actual.getErrorListener();
+    }
+
+    public TransformerHandler newTransformerHandler(Source src) throws TransformerConfigurationException {
+        if (saxtual == null)
+            throw new TransformerConfigurationException("Provider is not a SAXTransformerFactory");
+        return saxtual.newTransformerHandler(src);
+    }
+
+    public TransformerHandler newTransformerHandler(Templates templates) throws TransformerConfigurationException {
+        if (saxtual == null)
+            throw new TransformerConfigurationException("Provider is not a SAXTransformerFactory");
+        return saxtual.newTransformerHandler(templates);
+    }
+
+    public TransformerHandler newTransformerHandler() throws TransformerConfigurationException {
+        if (saxtual == null)
+            throw new TransformerConfigurationException("Provider is not a SAXTransformerFactory");
+        return saxtual.newTransformerHandler();
+    }
+
+    public TemplatesHandler newTemplatesHandler() throws TransformerConfigurationException {
+        if (saxtual == null)
+            throw new TransformerConfigurationException("Provider is not a SAXTransformerFactory");
+        return saxtual.newTemplatesHandler();
+    }
+
+    public XMLFilter newXMLFilter(Source src) throws TransformerConfigurationException {
+        if (saxtual == null)
+            throw new TransformerConfigurationException("Provider is not a SAXTransformerFactory");
+        return saxtual.newXMLFilter(src);
+    }
+
+    public XMLFilter newXMLFilter(Templates templates) throws TransformerConfigurationException {
+        if (saxtual == null)
+            throw new TransformerConfigurationException("Provider is not a SAXTransformerFactory");
+        return saxtual.newXMLFilter(templates);
+    }
+}

--- a/src/main/java/__redirected/__XMLEventFactory.java
+++ b/src/main/java/__redirected/__XMLEventFactory.java
@@ -1,0 +1,234 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Iterator;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.namespace.QName;
+import javax.xml.stream.Location;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Characters;
+import javax.xml.stream.events.Comment;
+import javax.xml.stream.events.DTD;
+import javax.xml.stream.events.EndDocument;
+import javax.xml.stream.events.EndElement;
+import javax.xml.stream.events.EntityDeclaration;
+import javax.xml.stream.events.EntityReference;
+import javax.xml.stream.events.Namespace;
+import javax.xml.stream.events.ProcessingInstruction;
+import javax.xml.stream.events.StartDocument;
+import javax.xml.stream.events.StartElement;
+
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+
+/**
+ * A redirected XMLEventFactory
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @authore Jason T. Greene
+ */
+@SuppressWarnings("unchecked")
+public final class __XMLEventFactory extends XMLEventFactory {
+    private static final Constructor<? extends XMLEventFactory> PLATFORM_FACTORY;
+    private static volatile Constructor<? extends XMLEventFactory> DEFAULT_FACTORY;
+
+    static {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+
+        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
+        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
+        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
+        // Thus, the class can not be found.
+        //
+        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
+        // the environment's TCCL
+        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
+        try {
+            if (System.getProperty(XMLEventFactory.class.getName(), "").equals(__XMLEventFactory.class.getName())) {
+                System.clearProperty(XMLEventFactory.class.getName());
+            }
+            XMLEventFactory factory = XMLEventFactory.newInstance();
+            try {
+                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+            System.setProperty(XMLEventFactory.class.getName(), __XMLEventFactory.class.getName());
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
+        Class<? extends XMLEventFactory> clazz = __RedirectedUtils.loadProvider(id, XMLEventFactory.class, loader);
+        if (clazz != null) {
+            try {
+                DEFAULT_FACTORY = clazz.getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+        }
+    }
+
+    public static void restorePlatformFactory() {
+        DEFAULT_FACTORY = PLATFORM_FACTORY;
+    }
+
+    /**
+     * Init method.
+     */
+    public static void init() {}
+
+    /**
+     * Construct a new instance.
+     */
+    public __XMLEventFactory() {
+        Constructor<? extends XMLEventFactory> factory = DEFAULT_FACTORY;
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try {
+            if (loader != null) {
+                Class<? extends XMLEventFactory> provider = __RedirectedUtils.loadProvider(XMLEventFactory.class, loader);
+                if (provider != null)
+                    factory = provider.getConstructor();
+            }
+
+            actual = factory.newInstance();
+        } catch (InstantiationException e) {
+            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
+        } catch (IllegalAccessException e) {
+            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
+        } catch (InvocationTargetException e) {
+            throw __RedirectedUtils.rethrowCause(e);
+        } catch (NoSuchMethodException e) {
+            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        }
+    }
+
+    private final XMLEventFactory actual;
+
+    public void setLocation(final Location location) {
+        actual.setLocation(location);
+    }
+
+    public Attribute createAttribute(final String prefix, final String namespaceURI, final String localName, final String value) {
+        return actual.createAttribute(prefix, namespaceURI, localName, value);
+    }
+
+    public Attribute createAttribute(final String localName, final String value) {
+        return actual.createAttribute(localName, value);
+    }
+
+    public Attribute createAttribute(final QName name, final String value) {
+        return actual.createAttribute(name, value);
+    }
+
+    public Namespace createNamespace(final String namespaceURI) {
+        return actual.createNamespace(namespaceURI);
+    }
+
+    public Namespace createNamespace(final String prefix, final String namespaceUri) {
+        return actual.createNamespace(prefix, namespaceUri);
+    }
+
+    public StartElement createStartElement(final QName name, final Iterator attributes, final Iterator namespaces) {
+        return actual.createStartElement(name, attributes, namespaces);
+    }
+
+    public StartElement createStartElement(final String prefix, final String namespaceUri, final String localName) {
+        return actual.createStartElement(prefix, namespaceUri, localName);
+    }
+
+    public StartElement createStartElement(final String prefix, final String namespaceUri, final String localName, final Iterator attributes, final Iterator namespaces) {
+        return actual.createStartElement(prefix, namespaceUri, localName, attributes, namespaces);
+    }
+
+    public StartElement createStartElement(final String prefix, final String namespaceUri, final String localName, final Iterator attributes, final Iterator namespaces, final NamespaceContext context) {
+        return actual.createStartElement(prefix, namespaceUri, localName, attributes, namespaces, context);
+    }
+
+    public EndElement createEndElement(final QName name, final Iterator namespaces) {
+        return actual.createEndElement(name, namespaces);
+    }
+
+    public EndElement createEndElement(final String prefix, final String namespaceUri, final String localName) {
+        return actual.createEndElement(prefix, namespaceUri, localName);
+    }
+
+    public EndElement createEndElement(final String prefix, final String namespaceUri, final String localName, final Iterator namespaces) {
+        return actual.createEndElement(prefix, namespaceUri, localName, namespaces);
+    }
+
+    public Characters createCharacters(final String content) {
+        return actual.createCharacters(content);
+    }
+
+    public Characters createCData(final String content) {
+        return actual.createCData(content);
+    }
+
+    public Characters createSpace(final String content) {
+        return actual.createSpace(content);
+    }
+
+    public Characters createIgnorableSpace(final String content) {
+        return actual.createIgnorableSpace(content);
+    }
+
+    public StartDocument createStartDocument() {
+        return actual.createStartDocument();
+    }
+
+    public StartDocument createStartDocument(final String encoding, final String version, final boolean standalone) {
+        return actual.createStartDocument(encoding, version, standalone);
+    }
+
+    public StartDocument createStartDocument(final String encoding, final String version) {
+        return actual.createStartDocument(encoding, version);
+    }
+
+    public StartDocument createStartDocument(final String encoding) {
+        return actual.createStartDocument(encoding);
+    }
+
+    public EndDocument createEndDocument() {
+        return actual.createEndDocument();
+    }
+
+    public EntityReference createEntityReference(final String name, final EntityDeclaration declaration) {
+        return actual.createEntityReference(name, declaration);
+    }
+
+    public Comment createComment(final String text) {
+        return actual.createComment(text);
+    }
+
+    public ProcessingInstruction createProcessingInstruction(final String target, final String data) {
+        return actual.createProcessingInstruction(target, data);
+    }
+
+    public DTD createDTD(final String dtd) {
+        return actual.createDTD(dtd);
+    }
+}

--- a/src/main/java/__redirected/__XMLInputFactory.java
+++ b/src/main/java/__redirected/__XMLInputFactory.java
@@ -1,0 +1,220 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.xml.stream.EventFilter;
+import javax.xml.stream.StreamFilter;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLReporter;
+import javax.xml.stream.XMLResolver;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.util.XMLEventAllocator;
+import javax.xml.transform.Source;
+
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+
+/**
+ * A redirected XMLInputFactory
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @authore Jason T. Greene
+ */
+public final class __XMLInputFactory extends XMLInputFactory {
+    private static final Constructor<? extends XMLInputFactory> PLATFORM_FACTORY;
+    private static volatile Constructor<? extends XMLInputFactory> DEFAULT_FACTORY;
+
+    static {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+
+        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
+        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
+        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
+        // Thus, the class can not be found.
+        //
+        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
+        // the environment's TCCL
+        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
+        try {
+            if (System.getProperty(XMLInputFactory.class.getName(), "").equals(__XMLInputFactory .class.getName())) {
+                System.clearProperty(XMLInputFactory.class.getName());
+            }
+            XMLInputFactory factory = XMLInputFactory.newInstance();
+            try {
+                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+            System.setProperty(XMLInputFactory.class.getName(), __XMLInputFactory.class.getName());
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
+        Class<? extends XMLInputFactory> clazz = __RedirectedUtils.loadProvider(id, XMLInputFactory.class, loader);
+        if (clazz != null) {
+            try {
+                DEFAULT_FACTORY = clazz.getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+        }
+    }
+
+    /**
+     * Init method.
+     */
+    public static void init() {}
+
+    public static void restorePlatformFactory() {
+        DEFAULT_FACTORY = PLATFORM_FACTORY;
+    }
+
+    /**
+     * Construct a new instance.
+     */
+    public __XMLInputFactory() {
+        Constructor<? extends XMLInputFactory> factory = DEFAULT_FACTORY;
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try {
+            if (loader != null) {
+                Class<? extends XMLInputFactory> provider = __RedirectedUtils.loadProvider(XMLInputFactory.class, loader);
+                if (provider != null)
+                    factory = provider.getConstructor();
+            }
+
+            actual = factory.newInstance();
+        } catch (InstantiationException e) {
+            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
+        } catch (IllegalAccessException e) {
+            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
+        } catch (InvocationTargetException e) {
+            throw __RedirectedUtils.rethrowCause(e);
+        } catch (NoSuchMethodException e) {
+            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        }
+    }
+
+    private final XMLInputFactory actual;
+
+    public XMLStreamReader createXMLStreamReader(final Reader reader) throws XMLStreamException {
+        return actual.createXMLStreamReader(reader);
+    }
+
+    public XMLStreamReader createXMLStreamReader(final Source source) throws XMLStreamException {
+        return actual.createXMLStreamReader(source);
+    }
+
+    public XMLStreamReader createXMLStreamReader(final InputStream stream) throws XMLStreamException {
+        return actual.createXMLStreamReader(stream);
+    }
+
+    public XMLStreamReader createXMLStreamReader(final InputStream stream, final String encoding) throws XMLStreamException {
+        return actual.createXMLStreamReader(stream, encoding);
+    }
+
+    public XMLStreamReader createXMLStreamReader(final String systemId, final InputStream stream) throws XMLStreamException {
+        return actual.createXMLStreamReader(systemId, stream);
+    }
+
+    public XMLStreamReader createXMLStreamReader(final String systemId, final Reader reader) throws XMLStreamException {
+        return actual.createXMLStreamReader(systemId, reader);
+    }
+
+    public XMLEventReader createXMLEventReader(final Reader reader) throws XMLStreamException {
+        return actual.createXMLEventReader(reader);
+    }
+
+    public XMLEventReader createXMLEventReader(final String systemId, final Reader reader) throws XMLStreamException {
+        return actual.createXMLEventReader(systemId, reader);
+    }
+
+    public XMLEventReader createXMLEventReader(final XMLStreamReader reader) throws XMLStreamException {
+        return actual.createXMLEventReader(reader);
+    }
+
+    public XMLEventReader createXMLEventReader(final Source source) throws XMLStreamException {
+        return actual.createXMLEventReader(source);
+    }
+
+    public XMLEventReader createXMLEventReader(final InputStream stream) throws XMLStreamException {
+        return actual.createXMLEventReader(stream);
+    }
+
+    public XMLEventReader createXMLEventReader(final InputStream stream, final String encoding) throws XMLStreamException {
+        return actual.createXMLEventReader(stream, encoding);
+    }
+
+    public XMLEventReader createXMLEventReader(final String systemId, final InputStream stream) throws XMLStreamException {
+        return actual.createXMLEventReader(systemId, stream);
+    }
+
+    public XMLStreamReader createFilteredReader(final XMLStreamReader reader, final StreamFilter filter) throws XMLStreamException {
+        return actual.createFilteredReader(reader, filter);
+    }
+
+    public XMLEventReader createFilteredReader(final XMLEventReader reader, final EventFilter filter) throws XMLStreamException {
+        return actual.createFilteredReader(reader, filter);
+    }
+
+    public XMLResolver getXMLResolver() {
+        return actual.getXMLResolver();
+    }
+
+    public void setXMLResolver(final XMLResolver resolver) {
+        actual.setXMLResolver(resolver);
+    }
+
+    public XMLReporter getXMLReporter() {
+        return actual.getXMLReporter();
+    }
+
+    public void setXMLReporter(final XMLReporter reporter) {
+        actual.setXMLReporter(reporter);
+    }
+
+    public void setProperty(final String name, final Object value) throws IllegalArgumentException {
+        actual.setProperty(name, value);
+    }
+
+    public Object getProperty(final String name) throws IllegalArgumentException {
+        return actual.getProperty(name);
+    }
+
+    public boolean isPropertySupported(final String name) {
+        return actual.isPropertySupported(name);
+    }
+
+    public void setEventAllocator(final XMLEventAllocator allocator) {
+        actual.setEventAllocator(allocator);
+    }
+
+    public XMLEventAllocator getEventAllocator() {
+        return actual.getEventAllocator();
+    }
+}

--- a/src/main/java/__redirected/__XMLOutputFactory.java
+++ b/src/main/java/__redirected/__XMLOutputFactory.java
@@ -1,0 +1,163 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import java.io.OutputStream;
+import java.io.Writer;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.xml.stream.XMLEventWriter;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import javax.xml.transform.Result;
+
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+
+/**
+ * A redirected XMLOutputFactory
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @authore Jason T. Greene
+ */
+public final class __XMLOutputFactory extends XMLOutputFactory {
+    private static final Constructor<? extends XMLOutputFactory> PLATFORM_FACTORY;
+    private static volatile Constructor<? extends XMLOutputFactory> DEFAULT_FACTORY;
+
+    static {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+
+        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
+        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
+        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
+        // Thus, the class can not be found.
+        //
+        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
+        // the environment's TCCL
+        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
+        try {
+            if (System.getProperty(XMLOutputFactory.class.getName(), "").equals(__XMLOutputFactory.class.getName())) {
+                System.clearProperty(XMLOutputFactory.class.getName());
+            }
+            XMLOutputFactory factory = XMLOutputFactory.newInstance();
+            try {
+                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+            System.setProperty(XMLOutputFactory.class.getName(), __XMLOutputFactory.class.getName());
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
+        Class<? extends XMLOutputFactory> clazz = __RedirectedUtils.loadProvider(id, XMLOutputFactory.class, loader);
+        if (clazz != null) {
+            try {
+                DEFAULT_FACTORY = clazz.getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+        }
+    }
+
+    public static void restorePlatformFactory() {
+        DEFAULT_FACTORY = PLATFORM_FACTORY;
+    }
+
+    /**
+     * Init method.
+     */
+    public static void init() {}
+
+    /**
+     * Construct a new instance.
+     */
+    public __XMLOutputFactory() {
+        Constructor<? extends XMLOutputFactory> factory = DEFAULT_FACTORY;
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try {
+            if (loader != null) {
+                Class<? extends XMLOutputFactory> provider = __RedirectedUtils.loadProvider(XMLOutputFactory.class, loader);
+                if (provider != null)
+                    factory = provider.getConstructor();
+            }
+
+            actual = factory.newInstance();
+        } catch (InstantiationException e) {
+            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
+        } catch (IllegalAccessException e) {
+            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
+        } catch (InvocationTargetException e) {
+            throw __RedirectedUtils.rethrowCause(e);
+        } catch (NoSuchMethodException e) {
+            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        }
+    }
+
+    private final XMLOutputFactory actual;
+
+    public XMLStreamWriter createXMLStreamWriter(final Writer stream) throws XMLStreamException {
+        return actual.createXMLStreamWriter(stream);
+    }
+
+    public XMLStreamWriter createXMLStreamWriter(final OutputStream stream) throws XMLStreamException {
+        return actual.createXMLStreamWriter(stream);
+    }
+
+    public XMLStreamWriter createXMLStreamWriter(final OutputStream stream, final String encoding) throws XMLStreamException {
+        return actual.createXMLStreamWriter(stream, encoding);
+    }
+
+    public XMLStreamWriter createXMLStreamWriter(final Result result) throws XMLStreamException {
+        return actual.createXMLStreamWriter(result);
+    }
+
+    public XMLEventWriter createXMLEventWriter(final Result result) throws XMLStreamException {
+        return actual.createXMLEventWriter(result);
+    }
+
+    public XMLEventWriter createXMLEventWriter(final OutputStream stream) throws XMLStreamException {
+        return actual.createXMLEventWriter(stream);
+    }
+
+    public XMLEventWriter createXMLEventWriter(final OutputStream stream, final String encoding) throws XMLStreamException {
+        return actual.createXMLEventWriter(stream, encoding);
+    }
+
+    public XMLEventWriter createXMLEventWriter(final Writer stream) throws XMLStreamException {
+        return actual.createXMLEventWriter(stream);
+    }
+
+    public void setProperty(final String name, final Object value) throws IllegalArgumentException {
+        actual.setProperty(name, value);
+    }
+
+    public Object getProperty(final String name) throws IllegalArgumentException {
+        return actual.getProperty(name);
+    }
+
+    public boolean isPropertySupported(final String name) {
+        return actual.isPropertySupported(name);
+    }
+}

--- a/src/main/java/__redirected/__XMLReaderFactory.java
+++ b/src/main/java/__redirected/__XMLReaderFactory.java
@@ -1,0 +1,182 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.DTDHandler;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.XMLReaderFactory;
+
+/**
+ * A redirected SAXParserFactory
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @authore Jason T. Greene
+ */
+public final class __XMLReaderFactory implements XMLReader {
+    private static final Constructor<? extends XMLReader> PLATFORM_FACTORY;
+    private static volatile Constructor<? extends XMLReader> DEFAULT_FACTORY;
+
+    private static final String SAX_DRIVER = "org.xml.sax.driver";
+
+    static {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+
+        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
+        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
+        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
+        // Thus, the class can not be found.
+        //
+        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
+        // the environment's TCCL
+        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
+        try {
+            if (System.getProperty(SAX_DRIVER, "").equals(__XMLReaderFactory.class.getName())) {
+                System.clearProperty(SAX_DRIVER);
+            }
+            XMLReader factory = XMLReaderFactory.createXMLReader();
+            try {
+               DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+            System.setProperty(SAX_DRIVER, __XMLReaderFactory.class.getName());
+        } catch (SAXException e) {
+             throw __RedirectedUtils.wrapped(new RuntimeException(e.getMessage()), e);
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
+        Class<? extends XMLReader> clazz = __RedirectedUtils.loadProvider(id, XMLReader.class, loader, SAX_DRIVER);
+        if (clazz != null) {
+            try {
+                DEFAULT_FACTORY = clazz.getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+        }
+    }
+
+    public static void restorePlatformFactory() {
+        DEFAULT_FACTORY = PLATFORM_FACTORY;
+    }
+
+    /**
+     * Init method.
+     */
+    public static void init() {}
+
+    /**
+     * Construct a new instance.
+     */
+    public __XMLReaderFactory() {
+        Constructor<? extends XMLReader> factory = DEFAULT_FACTORY;
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try {
+            if (loader != null) {
+                Class<? extends XMLReader> provider = __RedirectedUtils.loadProvider(XMLReader.class, loader, SAX_DRIVER);
+                if (provider != null)
+                    factory = provider.getConstructor();
+            }
+
+            actual = factory.newInstance();
+        } catch (InstantiationException e) {
+            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
+        } catch (IllegalAccessException e) {
+            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
+        } catch (InvocationTargetException e) {
+            throw __RedirectedUtils.rethrowCause(e);
+        } catch (NoSuchMethodException e) {
+            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        }
+    }
+
+    private final XMLReader actual;
+
+    public boolean getFeature(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
+        return actual.getFeature(name);
+    }
+
+    public void setFeature(String name, boolean value) throws SAXNotRecognizedException, SAXNotSupportedException {
+        actual.setFeature(name, value);
+    }
+
+    public Object getProperty(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
+        return actual.getProperty(name);
+    }
+
+    public void setProperty(String name, Object value) throws SAXNotRecognizedException, SAXNotSupportedException {
+        actual.setProperty(name, value);
+    }
+
+    public void setEntityResolver(EntityResolver resolver) {
+        actual.setEntityResolver(resolver);
+    }
+
+    public EntityResolver getEntityResolver() {
+        return actual.getEntityResolver();
+    }
+
+    public void setDTDHandler(DTDHandler handler) {
+        actual.setDTDHandler(handler);
+    }
+
+    public DTDHandler getDTDHandler() {
+        return actual.getDTDHandler();
+    }
+
+    public void setContentHandler(ContentHandler handler) {
+        actual.setContentHandler(handler);
+    }
+
+    public ContentHandler getContentHandler() {
+        return actual.getContentHandler();
+    }
+
+    public void setErrorHandler(ErrorHandler handler) {
+        actual.setErrorHandler(handler);
+    }
+
+    public ErrorHandler getErrorHandler() {
+        return actual.getErrorHandler();
+    }
+
+    public void parse(InputSource input) throws IOException, SAXException {
+        actual.parse(input);
+    }
+
+    public void parse(String systemId) throws IOException, SAXException {
+        actual.parse(systemId);
+    }
+}

--- a/src/main/java/__redirected/__XPathFactory.java
+++ b/src/main/java/__redirected/__XPathFactory.java
@@ -1,0 +1,145 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathFactoryConfigurationException;
+import javax.xml.xpath.XPathFunctionResolver;
+import javax.xml.xpath.XPathVariableResolver;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+/**
+ * A redirected XPathFactory
+ *
+ * @author Jason T. Greene
+ */
+public final class __XPathFactory extends XPathFactory {
+    private static final Constructor<? extends XPathFactory> PLATFORM_FACTORY;
+    private static volatile Constructor<? extends XPathFactory> DEFAULT_FACTORY;
+
+    static {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+
+        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
+        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
+        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
+        // Thus, the class can not be found.
+        //
+        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
+        // the environment's TCCL
+        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
+        try {
+            if (System.getProperty(XPathFactory.class.getName(), "").equals(__XPathFactory.class.getName())) {
+                System.clearProperty(XPathFactory.class.getName());
+            }
+            XPathFactory factory = XPathFactory.newInstance();
+            try {
+                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+            System.setProperty(XPathFactory.class.getName() + ":" + XPathFactory.DEFAULT_OBJECT_MODEL_URI, __XPathFactory.class.getName());
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
+        Class<? extends XPathFactory> clazz = __RedirectedUtils.loadProvider(id, XPathFactory.class, loader);
+        if (clazz != null) {
+            try {
+                DEFAULT_FACTORY = clazz.getConstructor();
+            } catch (NoSuchMethodException e) {
+                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+            }
+        }
+    }
+
+    public static void restorePlatformFactory() {
+        DEFAULT_FACTORY = PLATFORM_FACTORY;
+    }
+
+    /**
+     * Init method.
+     */
+    public static void init() {}
+
+    /**
+     * Construct a new instance.
+     */
+    public __XPathFactory() {
+        Constructor<? extends XPathFactory> factory = DEFAULT_FACTORY;
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        XPathFactory foundInstance = null;
+        try {
+            if (loader != null) {
+                List<Class<? extends XPathFactory>> providers = __RedirectedUtils.loadProviders(XPathFactory.class, loader);
+                for (Class<? extends XPathFactory> provider : providers) {
+                    XPathFactory instance = provider.newInstance();
+                    if (instance.isObjectModelSupported(XPathFactory.DEFAULT_OBJECT_MODEL_URI)) {
+                        foundInstance = instance;
+                        break;
+                    }
+                }
+            }
+
+            actual = foundInstance != null ? foundInstance : factory.newInstance();
+
+        } catch (InstantiationException e) {
+            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
+        } catch (IllegalAccessException e) {
+            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
+        } catch (InvocationTargetException e) {
+            throw __RedirectedUtils.rethrowCause(e);
+        }
+    }
+
+    private final XPathFactory actual;
+
+    public boolean isObjectModelSupported(String objectModel) {
+        return actual.isObjectModelSupported(objectModel);
+    }
+
+    public void setFeature(String name, boolean value) throws XPathFactoryConfigurationException {
+        actual.setFeature(name, value);
+    }
+
+    public boolean getFeature(String name) throws XPathFactoryConfigurationException {
+        return actual.getFeature(name);
+    }
+
+    public void setXPathVariableResolver(XPathVariableResolver resolver) {
+        actual.setXPathVariableResolver(resolver);
+    }
+
+    public void setXPathFunctionResolver(XPathFunctionResolver resolver) {
+        actual.setXPathFunctionResolver(resolver);
+    }
+
+    public XPath newXPath() {
+        return actual.newXPath();
+    }
+}

--- a/src/main/java/org/jboss/modules/Main.java
+++ b/src/main/java/org/jboss/modules/Main.java
@@ -18,6 +18,8 @@
 
 package org.jboss.modules;
 
+import __redirected.__JAXPRedirected;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -89,6 +91,8 @@ public final class Main {
         System.out.println("    -deptree      Print the dependency tree of the given module instead of running it");
         System.out.println("    -jar          Specify that the final argument is the name of a");
         System.out.println("                  JAR file to run as a module; not compatible with -class");
+        System.out.println("    -jaxpmodule <module-spec>");
+        System.out.println("                  The default JAXP implementation to use of the JDK");
         System.out.println("    -secmgr       Run with a security manager installed; not compatible with -secmgrmodule");
         System.out.println("    -secmgrmodule <module-spec>");
         System.out.println("                  Run with a security manager module; not compatible with -secmgr");
@@ -371,6 +375,11 @@ public final class Main {
             moduleIdentifier = ModuleIdentifier.fromString(nameArgument);
         }
         Module.initBootModuleLoader(loader);
+        if (jaxpModuleIdentifier != null) {
+            __JAXPRedirected.changeAll(jaxpModuleIdentifier, Module.getBootModuleLoader());
+        } else {
+            __JAXPRedirected.changeAll(moduleIdentifier, Module.getBootModuleLoader());
+        }
 
         final Module module;
         try {

--- a/src/main/java/org/jboss/modules/Module.java
+++ b/src/main/java/org/jboss/modules/Module.java
@@ -52,6 +52,7 @@ import org.jboss.modules.filter.PathFilters;
 import org.jboss.modules.log.ModuleLogger;
 import org.jboss.modules.log.NoopModuleLogger;
 
+import __redirected.__JAXPRedirected;
 import org.jboss.modules.security.ModularPermissionFactory;
 
 /**
@@ -126,6 +127,8 @@ public final class Module {
                 } catch (Throwable t) {
                     // todo log a warning or something
                 }
+
+                __JAXPRedirected.initAll();
 
                 return null;
             }

--- a/src/test/java/org/jboss/modules/JAXPModuleTest.java
+++ b/src/test/java/org/jboss/modules/JAXPModuleTest.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Calendar;
@@ -30,6 +31,7 @@ import java.util.GregorianCalendar;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
+
 import javax.xml.XMLConstants;
 import javax.xml.datatype.DatatypeConstants.Field;
 import javax.xml.datatype.DatatypeFactory;
@@ -75,6 +77,7 @@ import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TemplatesHandler;
@@ -91,12 +94,26 @@ import javax.xml.xpath.XPathFactoryConfigurationException;
 import javax.xml.xpath.XPathFunctionResolver;
 import javax.xml.xpath.XPathVariableResolver;
 
+import __redirected.__SchemaFactory;
+import __redirected.__XMLReaderFactory;
+import __redirected.__XPathFactory;
+import __redirected.__DatatypeFactory;
+import __redirected.__DocumentBuilderFactory;
+import __redirected.__JAXPRedirected;
+import __redirected.__SAXParserFactory;
+import __redirected.__TransformerFactory;
+import __redirected.__XMLEventFactory;
+import __redirected.__XMLInputFactory;
+import __redirected.__XMLOutputFactory;
+
 import org.jboss.modules.filter.PathFilter;
 import org.jboss.modules.filter.PathFilters;
 import org.jboss.modules.test.JAXPCaller;
 import org.jboss.modules.util.TestModuleLoader;
 import org.jboss.modules.util.TestResourceLoader;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.ls.LSResourceResolver;
@@ -191,6 +208,269 @@ public class JAXPModuleTest extends AbstractModuleTestCase {
             return (T) obj.getClass().getMethod(method).invoke(obj);
         } catch (Exception e) {
             throw new IllegalStateException(e);
+        }
+    }
+
+    @Test
+    public void testJVMDefault() throws Exception {
+        ModuleClassLoader cl = moduleLoader.loadModule(ModuleIdentifier.fromString("test-jaxp")).getClassLoader();
+        ClassLoader old = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(cl);
+            Class<?> clazz = cl.loadClass("org.jboss.modules.test.JAXPCaller");
+            checkDom(clazz, false);
+            checkSax(clazz, false);
+            checkTransformer(clazz, false);
+            checkSAXTransformer(clazz, false);
+            checkXPath(clazz, false);
+            checkXmlEvent(clazz, false);
+            checkXmlInput(clazz, false);
+            checkXmlOutput(clazz, false);
+            checkDatatype(clazz, false);
+            checkSchema(clazz, false);
+            checkXMLReader(clazz, false);
+        } finally {
+            Thread.currentThread().setContextClassLoader(old);
+        }
+    }
+
+    @Test
+    public void testReplaceDefault() throws Exception {
+        __JAXPRedirected.changeAll(FAKE_JAXP, moduleLoader);
+
+        ModuleClassLoader cl = moduleLoader.loadModule(ModuleIdentifier.fromString("test-jaxp")).getClassLoader();
+        Class<?> clazz = cl.loadClass("org.jboss.modules.test.JAXPCaller");
+        ClassLoader old = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(cl);
+            checkDom(clazz, true);
+            checkSax(clazz, true);
+            checkTransformer(clazz, true);
+            checkSAXTransformer(clazz, true);
+            checkXPath(clazz, true);
+            checkXmlEvent(clazz, true);
+            checkXmlInput(clazz, true);
+            checkXmlOutput(clazz, true);
+            checkDatatype(clazz, true);
+            checkSchema(clazz, true);
+            checkXMLReader(clazz, true);
+        } finally {
+            Thread.currentThread().setContextClassLoader(old);
+            __JAXPRedirected.restorePlatformFactory();
+        }
+    }
+
+    @Test
+    public void testImport() throws Exception {
+        ModuleClassLoader cl = moduleLoader.loadModule(ModuleIdentifier.fromString("test-jaxp-import")).getClassLoader();
+        Class<?> clazz = cl.loadClass("org.jboss.modules.test.JAXPCaller");
+        ClassLoader old = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(cl);
+            checkDom(clazz, true);
+            checkSax(clazz, true);
+            checkTransformer(clazz, true);
+            checkSAXTransformer(clazz, true);
+            checkXPath(clazz, true);
+            checkXmlEvent(clazz, true);
+            checkXmlInput(clazz, true);
+            checkXmlOutput(clazz, true);
+            checkDatatype(clazz, true);
+            checkSchema(clazz, true);
+            checkXMLReader(clazz, true);
+        } finally {
+            Thread.currentThread().setContextClassLoader(old);
+        }
+    }
+
+    /*
+     * This test is slightly dangerous. If it causes problems, just add @Ignore
+     * and/or let me know.
+     *   -Jason
+     */
+    @Test
+    public void testMain() throws Throwable {
+        java.lang.reflect.Field field = DefaultBootModuleLoaderHolder.class.getDeclaredField("INSTANCE");
+        java.lang.reflect.Field modifiersField = java.lang.reflect.Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.setAccessible(true);
+        ModuleLoader oldMl = (ModuleLoader) field.get(null);
+        field.set(null, moduleLoader);
+
+        Main.main(new String[] {"-jaxpmodule", "fake-jaxp", "test-jaxp"});
+        ModuleClassLoader cl = moduleLoader.loadModule(ModuleIdentifier.fromString("test-jaxp")).getClassLoader();
+        Class<?> clazz = cl.loadClass("org.jboss.modules.test.JAXPCaller");
+        ClassLoader old = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(cl);
+            checkDom(clazz, true);
+            checkSax(clazz, true);
+            checkTransformer(clazz, true);
+            checkSAXTransformer(clazz, true);
+            checkXmlEvent(clazz, true);
+            checkXPath(clazz, true);
+            checkXmlInput(clazz, true);
+            checkXmlOutput(clazz, true);
+            checkDatatype(clazz, true);
+            checkSchema(clazz, true);
+            checkXMLReader(clazz, true);
+        } finally {
+            field.set(null, oldMl);
+            Thread.currentThread().setContextClassLoader(old);
+            __JAXPRedirected.restorePlatformFactory();
+        }
+    }
+
+    public void checkDom(Class<?> clazz, boolean fake) throws Exception {
+        DocumentBuilder builder = invokeMethod(clazz.newInstance(), "documentBuilder");
+        DocumentBuilderFactory factory = invokeMethod(clazz.newInstance(), "documentFactory");
+
+        Assert.assertEquals(__DocumentBuilderFactory.class.getName(), factory.getClass().getName());
+
+        if (fake) {
+            Assert.assertEquals(FakeDocumentBuilder.class.getName(), builder.getClass().getName());
+        } else {
+            // Double check that it works
+            Document document = invokeMethod(clazz.newInstance(), "document");
+            document.createElement("test");
+            Assert.assertSame(DocumentBuilderFactory.newInstance().newDocumentBuilder().getClass(), builder.getClass());
+        }
+    }
+
+    public void checkSax(Class<?> clazz, boolean fake) throws Exception {
+        SAXParser parser = invokeMethod(clazz.newInstance(), "saxParser");
+        SAXParserFactory factory = invokeMethod(clazz.newInstance(), "saxParserFactory");
+
+        Assert.assertEquals(__SAXParserFactory.class.getName(), factory.getClass().getName());
+
+        if (fake) {
+            Assert.assertEquals(FakeSAXParser.class.getName(), parser.getClass().getName());
+        } else {
+            Assert.assertSame(SAXParserFactory.newInstance().newSAXParser().getClass(), parser.getClass());
+        }
+    }
+
+    public void checkTransformer(Class<?> clazz, boolean fake) throws Exception {
+        Transformer parser = invokeMethod(clazz.newInstance(), "transformer");
+        TransformerFactory factory = invokeMethod(clazz.newInstance(), "transformerFactory");
+
+        Assert.assertEquals(__TransformerFactory.class.getName(), factory.getClass().getName());
+
+        if (fake) {
+            Assert.assertEquals(FakeTransformer.class.getName(), parser.getClass().getName());
+        } else {
+            Assert.assertSame(TransformerFactory.newInstance().newTransformer().getClass(), parser.getClass());
+        }
+    }
+
+    public void checkXPath(Class<?> clazz, boolean fake) throws Exception {
+        XPath parser = invokeMethod(clazz.newInstance(), "xpath");
+        XPathFactory factory = invokeMethod(clazz.newInstance(), "xpathFactory");
+
+        Assert.assertEquals(__XPathFactory.class.getName(), factory.getClass().getName());
+
+        if (fake) {
+            Assert.assertEquals(FakeXPath.class.getName(), parser.getClass().getName());
+        } else {
+            Assert.assertSame(XPathFactory.newInstance().newXPath().getClass(), parser.getClass());
+        }
+    }
+
+    public void checkSchema(Class<?> clazz, boolean fake) throws Exception {
+        Schema parser = invokeMethod(clazz.newInstance(), "schema");
+        SchemaFactory factory = invokeMethod(clazz.newInstance(), "schemaFactory");
+
+        Assert.assertEquals(__SchemaFactory.class.getName(), factory.getClass().getName());
+
+        if (fake) {
+            Assert.assertEquals(FakeSchema.class.getName(), parser.getClass().getName());
+        } else {
+            Assert.assertSame(SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema().getClass(), parser.getClass());
+        }
+    }
+
+    public void checkXMLReader(Class<?> clazz, boolean fake) throws Exception {
+        XMLReader parser = invokeMethod(clazz.newInstance(), "xmlReader");
+
+        Assert.assertEquals(__XMLReaderFactory.class.getName(), parser.getClass().getName());
+
+
+        Object test = null;
+        try {
+            test = parser.getProperty("test");
+        } catch (Exception ignore) {
+        }
+
+        if (fake) {
+            Assert.assertEquals("fake-fake-fake", test);
+        } else {
+            Assert.assertFalse("fake-fake-fake".equals(test));
+        }
+    }
+
+    public void checkSAXTransformer(Class<?> clazz, boolean fake) throws Exception {
+        TransformerHandler transformerHandler = invokeMethod(clazz.newInstance(), "transformerHandler");
+        TransformerFactory factory = invokeMethod(clazz.newInstance(), "transformerFactory");
+
+        Assert.assertEquals(__TransformerFactory.class.getName(), factory.getClass().getName());
+
+        if (fake) {
+            Assert.assertEquals(FakeTransformerHandler.class.getName(), transformerHandler.getClass().getName());
+        } else {
+            Assert.assertSame(((SAXTransformerFactory) TransformerFactory.newInstance()).newTransformerHandler().getClass(), transformerHandler.getClass());
+        }
+    }
+
+    public void checkXmlEvent(Class<?> clazz, boolean fake) throws Exception {
+        DTD dtd = invokeMethod(clazz.newInstance(), "eventDTD");
+        XMLEventFactory factory = invokeMethod(clazz.newInstance(), "eventFactory");
+
+        Assert.assertEquals(__XMLEventFactory.class.getName(), factory.getClass().getName());
+
+        if (fake) {
+            Assert.assertEquals(FakeDTD.class.getName(), dtd.getClass().getName());
+        } else {
+            Assert.assertSame(XMLEventFactory.newInstance().createDTD("blah").getClass(), dtd.getClass());
+        }
+    }
+
+    public void checkXmlInput(Class<?> clazz, boolean fake) throws Exception {
+        String property = invokeMethod(clazz.newInstance(), "inputProperty");
+        XMLInputFactory factory = invokeMethod(clazz.newInstance(), "inputFactory");
+
+        Assert.assertEquals(__XMLInputFactory.class.getName(), factory.getClass().getName());
+
+        if (fake) {
+            Assert.assertEquals(new FakeXMLInputFactory().getProperty("blah"), property);
+        } else {
+            Assert.assertFalse(new FakeXMLInputFactory().getProperty("blah").equals(property));
+        }
+    }
+
+    public void checkXmlOutput(Class<?> clazz, boolean fake) throws Exception {
+        String property = invokeMethod(clazz.newInstance(), "outputProperty");
+        XMLOutputFactory factory = invokeMethod(clazz.newInstance(), "outputFactory");
+
+        Assert.assertEquals(__XMLOutputFactory.class.getName(), factory.getClass().getName());
+
+        if (fake) {
+            Assert.assertEquals(new FakeXMLOutputFactory().getProperty("blah"), property);
+        } else {
+            Assert.assertFalse(new FakeXMLInputFactory().getProperty("blah").equals(property));
+        }
+    }
+
+    public void checkDatatype(Class<?> clazz, boolean fake) throws Exception {
+        Duration duration = invokeMethod(clazz.newInstance(), "duration");
+        DatatypeFactory factory = invokeMethod(clazz.newInstance(), "datatypeFactory");
+
+        Assert.assertEquals(__DatatypeFactory.class.getName(), factory.getClass().getName());
+
+        if (fake) {
+            Assert.assertEquals(new FakeDuration().getSign(), duration.getSign());
+        } else {
+            Assert.assertFalse(new FakeDuration().getSign() == duration.getSign());
         }
     }
 


### PR DESCRIPTION
Reverts jboss-modules/jboss-modules#68.  We still need the ability to override the default JAXP providers, so this comes back until/unless we find a better option.