### PR TITLE
put a null guard around PropertyWriteAction

### DIFF
--- a/src/main/java/org/jboss/modules/ClassPathModuleLoader.java
+++ b/src/main/java/org/jboss/modules/ClassPathModuleLoader.java
@@ -41,12 +41,10 @@ final class ClassPathModuleLoader extends ModuleLoader {
         this.delegateLoader = delegateLoader;
         this.dependencies = dependencies;
         if (isEmpty(classPath)) {
-            classPath = System.getenv().get("CLASSPATH");
+            classPath = System.getenv().getOrDefault("CLASSPATH","");
         }
         this.classPath = classPath;
-        if(classPath != null){
-        	AccessController.doPrivileged(new PropertyWriteAction("java.class.path", classPath));
-        }
+       	AccessController.doPrivileged(new PropertyWriteAction("java.class.path", classPath));
         this.mainClass = mainClass;
     }
 

--- a/src/main/java/org/jboss/modules/ClassPathModuleLoader.java
+++ b/src/main/java/org/jboss/modules/ClassPathModuleLoader.java
@@ -44,7 +44,9 @@ final class ClassPathModuleLoader extends ModuleLoader {
             classPath = System.getenv().get("CLASSPATH");
         }
         this.classPath = classPath;
-        AccessController.doPrivileged(new PropertyWriteAction("java.class.path", classPath));
+        if(classPath != null){
+        	AccessController.doPrivileged(new PropertyWriteAction("java.class.path", classPath));
+        }
         this.mainClass = mainClass;
     }
 

--- a/src/main/java/org/jboss/modules/ClassPathModuleLoader.java
+++ b/src/main/java/org/jboss/modules/ClassPathModuleLoader.java
@@ -44,7 +44,7 @@ final class ClassPathModuleLoader extends ModuleLoader {
             classPath = System.getenv().getOrDefault("CLASSPATH","");
         }
         this.classPath = classPath;
-       	AccessController.doPrivileged(new PropertyWriteAction("java.class.path", classPath));
+        AccessController.doPrivileged(new PropertyWriteAction("java.class.path", classPath));
         this.mainClass = mainClass;
     }
 


### PR DESCRIPTION
classPath may be null when -class option is specified in Main and CLASSPATH environment variable is undefined.

This is the most expedient way to deal with it, but I'm not sure it's the best. 
Other options:
1) remove PropertyWriteAction entirely
java.class.path is already set by Main if -classpath option is specified but we should probably honor 
CLASSPATH for -class option.
2) provide a sensible default
replace line 44 with System.getenv().getOrDefault(). Though I'm not sure what a sensible, non-null default is for java.class.path. Is "" a valid value?