### PR TITLE
Implement NIO2 Path-based resource loader

### DIFF
--- a/src/main/java/org/jboss/modules/PathResource.java
+++ b/src/main/java/org/jboss/modules/PathResource.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.modules;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Java NIO Path-based Resource
+ *
+ * @author <a href="mailto:bsideup@gmail.com">Sergei Egorov</a>
+ */
+class PathResource implements Resource {
+
+    private final Path path;
+
+    PathResource(Path path) {
+        this.path = path;
+    }
+
+    @Override
+    public String getName() {
+        return path.toString();
+    }
+
+    @Override
+    public URL getURL() {
+        try {
+            return path.toUri().toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public InputStream openStream() throws IOException {
+        return Files.newInputStream(path);
+    }
+
+    @Override
+    public long getSize() {
+        try {
+            return Files.size(path);
+        } catch (IOException e) {
+            return 0;
+        }
+    }
+}

--- a/src/main/java/org/jboss/modules/PathResourceLoader.java
+++ b/src/main/java/org/jboss/modules/PathResourceLoader.java
@@ -1,0 +1,148 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.modules;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.CodeSigner;
+import java.security.CodeSource;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+
+/**
+ * Java NIO2 Path-based ResourceLoader
+ *
+ * @author <a href="mailto:bsideup@gmail.com">Sergei Egorov</a>
+ */
+final class PathResourceLoader extends AbstractResourceLoader implements IterableResourceLoader {
+
+    private final String rootName;
+    private final Path root;
+
+    private final Manifest manifest;
+    private final CodeSource codeSource;
+
+    PathResourceLoader(final String rootName, final Path root) {
+        if (rootName == null) {
+            throw new IllegalArgumentException("rootName is null");
+        }
+        if (root == null) {
+            throw new IllegalArgumentException("root is null");
+        }
+        this.rootName = rootName;
+        this.root = root;
+        final Path manifestFile = root.resolve("META-INF").resolve("MANIFEST.MF");
+        manifest = readManifestFile(manifestFile);
+
+        try {
+            codeSource = new CodeSource(root.toUri().toURL(), (CodeSigner[]) null);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid root file specified", e);
+        }
+    }
+
+    private static Manifest readManifestFile(final Path manifestFile) {
+        if (Files.isDirectory(manifestFile)) {
+            return null;
+        }
+
+        try {
+            try (InputStream is = Files.newInputStream(manifestFile)) {
+                return new Manifest(is);
+            }
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public String getRootName() {
+        return rootName;
+    }
+
+    @Override
+    public ClassSpec getClassSpec(final String fileName) throws IOException {
+        final Path file = root.resolve(fileName);
+        if (!Files.exists(file)) {
+            return null;
+        }
+        final ClassSpec spec = new ClassSpec();
+        spec.setCodeSource(codeSource);
+        spec.setBytes(Files.readAllBytes(file));
+        return spec;
+    }
+
+    @Override
+    public PackageSpec getPackageSpec(final String name) throws IOException {
+        return getPackageSpec(name, manifest, root.toUri().toURL());
+    }
+
+    @Override
+    public Resource getResource(final String name) {
+        final Path file = root.resolve(PathUtils.canonicalize(PathUtils.relativize(name)));
+
+        if (!Files.exists(file)) {
+            return null;
+        } else {
+            return new PathResource(file);
+        }
+    }
+
+    @Override
+    public Iterator<Resource> iterateResources(final String startPath, final boolean recursive) {
+        try {
+            Path path = root.resolve(PathUtils.canonicalize(PathUtils.relativize(startPath)));
+            return Files.walk(path, recursive ? Integer.MAX_VALUE : 1)
+                    .filter(it -> !Files.isDirectory(it))
+                    .map(root::relativize)
+                    .<Resource>map(PathResource::new)
+                    .iterator();
+        } catch (IOException e) {
+            return Collections.emptyIterator();
+        }
+    }
+
+    @Override
+    public Collection<String> getPaths() {
+        try {
+            final String separator = root.getFileSystem().getSeparator();
+            return Files.walk(root)
+                    .filter(Files::isDirectory)
+                    .map(dir -> {
+                        final String result = root.relativize(dir).toString();
+
+                        // JBoss modules expect folders not to end with a slash, so we have to strip it.
+                        if (result.endsWith(separator)) {
+                            return result.substring(0, result.length() - separator.length());
+                        } else {
+                            return result;
+                        }
+                    })
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            // do nothing
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/org/jboss/modules/ResourceLoaders.java
+++ b/src/main/java/org/jboss/modules/ResourceLoaders.java
@@ -19,6 +19,7 @@
 package org.jboss.modules;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.security.AccessController;
 import java.util.jar.JarFile;
 import org.jboss.modules.filter.PathFilter;
@@ -125,5 +126,16 @@ public final class ResourceLoaders {
      */
     public static IterableResourceLoader createIterableFilteredResourceLoader(final PathFilter pathFilter, final IterableResourceLoader originalLoader) {
         return new FilteredIterableResourceLoader(pathFilter, originalLoader);
+    }
+
+    /**
+     * Create a NIO2 Path-backed iterable resource loader.
+     *
+     * @param name the name of the resource root
+     * @param path the root path of the resource loader
+     * @return the resource loader
+     */
+    public static IterableResourceLoader createPathResourceLoader(final String name, final Path path) {
+        return new PathResourceLoader(name, path);
     }
 }

--- a/src/test/java/org/jboss/modules/AbstractResourceLoaderTestCase.java
+++ b/src/test/java/org/jboss/modules/AbstractResourceLoaderTestCase.java
@@ -54,7 +54,7 @@ public abstract class AbstractResourceLoaderTestCase extends AbstractModuleTestC
     }
 
     protected abstract ResourceLoader createLoader(final PathFilter exportFilter) throws Exception;
-    protected abstract void assertResource(final Resource resource, final String fileName);
+    protected abstract void assertResource(final Resource resource, final String fileName) throws Exception;
 
     @Test
     public void testBasicResource() throws Exception {

--- a/src/test/java/org/jboss/modules/JarResourceLoaderTest.java
+++ b/src/test/java/org/jboss/modules/JarResourceLoaderTest.java
@@ -59,14 +59,14 @@ public class JarResourceLoaderTest extends AbstractResourceLoaderTestCase {
         Assert.assertEquals(entry.getSize(), resource.getSize());
     }
 
-    private void buildJar(final File source, final File targetFile) throws IOException {
+    static void buildJar(final File source, final File targetFile) throws IOException {
         final JarOutputStream target = new JarOutputStream(new FileOutputStream(targetFile));
         final String sourceBase = source.getPath();
         add(sourceBase, source, target);
         target.close();
     }
 
-    private void add(final String sourceBase, final File source, final JarOutputStream target) throws IOException {
+    private static void add(final String sourceBase, final File source, final JarOutputStream target) throws IOException {
         BufferedInputStream in = null;
         String entryName = source.getPath().replace(sourceBase, "").replace("\\", "/");
         if(entryName.startsWith("/"))

--- a/src/test/java/org/jboss/modules/PathResourceLoaderTest.java
+++ b/src/test/java/org/jboss/modules/PathResourceLoaderTest.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.modules;
+
+import org.jboss.modules.filter.PathFilter;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Test the functionality of the PathResourceLoader
+ *
+ * @author Sergei Egorov
+ */
+@RunWith(Parameterized.class)
+public class PathResourceLoaderTest extends AbstractResourceLoaderTestCase {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {TestMode.FOLDER},
+                {TestMode.JAR}
+        });
+    }
+
+    @Parameterized.Parameter
+    public TestMode testMode;
+
+    private Path resourceRoot;
+
+    @Override
+    protected ResourceLoader createLoader(PathFilter exportFilter) throws Exception {
+        resourceRoot = testMode.getResourceRoot(this);
+
+        return ResourceLoaders.createPathResourceLoader("test-root", resourceRoot);
+    }
+
+    @Override
+    protected void assertResource(Resource resource, String fileName) throws IOException {
+        final Path resourceFile = resourceRoot.resolve(fileName);
+
+        Assert.assertEquals(Files.size(resourceFile), resource.getSize());
+        Assert.assertEquals(resourceFile.toUri().toURL(), resource.getURL());
+    }
+
+    private enum TestMode {
+        FOLDER,
+        JAR {
+            @Override
+            Path getResourceRoot(PathResourceLoaderTest test) throws Exception {
+                // Build a jar to match the fileresource loader
+                final File outputFile = new File(test.getResource("test"), "jarresourceloader/test.jar");
+                outputFile.getParentFile().mkdirs();
+                JarResourceLoaderTest.buildJar(super.getResourceRoot(test).toFile(), outputFile);
+
+                FileSystem fileSystem = FileSystems.newFileSystem(outputFile.toPath(), null);
+                return fileSystem.getRootDirectories().iterator().next();
+            }
+        };
+
+        Path getResourceRoot(PathResourceLoaderTest test) throws Exception {
+            Path resourceRoot = test.getResource("test/fileresourceloader").toPath().toAbsolutePath();
+            // Copy the classfile over
+            test.copyResource("org/jboss/modules/test/TestClass.class", "test/fileresourceloader", "org/jboss/modules/test");
+
+            return resourceRoot;
+        }
+    }
+}


### PR DESCRIPTION
Hi.

Currently, JBoss modules are using old, `java.io.File`-based FileResourceLoader and JarResourceLoader.

Since NIO2 was released, there is really nice FileSystem abstraction. This PR makes it possible to load resources from `Path`, which might be represented by different types of FileSystems, like:

LocalFileSystem (test included)
JarFileSystem (see the test as well)
Arquillian's ShrinkWrap since it implements FileSystem SPI
InMemoryFileSystems like http://github.com/google/jimfs
Some distributed file systems


Generally, I'm going to use PathResourceLoader in Forge's Furnace because I want to distribute Furnace.