### PR TITLE
Make FileResourceLoader extends PathResourceLoader and implement security checks

### DIFF
--- a/src/main/java/org/jboss/modules/FileResourceLoader.java
+++ b/src/main/java/org/jboss/modules/FileResourceLoader.java
@@ -18,357 +18,54 @@
 
 package org.jboss.modules;
 
-import static java.security.AccessController.doPrivileged;
-
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.lang.reflect.UndeclaredThrowableException;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.AccessControlContext;
-import java.security.CodeSigner;
-import java.security.CodeSource;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.jar.Manifest;
 
 /**
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
-final class FileResourceLoader extends NativeLibraryResourceLoader implements IterableResourceLoader {
-
-    private final String rootName;
-    private final Manifest manifest;
-    private final CodeSource codeSource;
-    private final AccessControlContext context;
+final class FileResourceLoader extends PathResourceLoader {
 
     FileResourceLoader(final String rootName, final File root, final AccessControlContext context) {
-        super(root);
-        if (root == null) {
-            throw new IllegalArgumentException("root is null");
-        }
-        if (rootName == null) {
-            throw new IllegalArgumentException("rootName is null");
-        }
-        if (context == null) {
-            throw new IllegalArgumentException("context is null");
-        }
-        this.rootName = rootName;
-        final File manifestFile = new File(root, "META-INF" + File.separatorChar + "MANIFEST.MF");
-        manifest = readManifestFile(manifestFile);
-        final URL rootUrl;
-        final SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            rootUrl = doPrivileged(new PrivilegedAction<URL>() {
-                public URL run() {
-                    try {
-                        return root.getAbsoluteFile().toURI().toURL();
-                    } catch (MalformedURLException e) {
-                        throw new IllegalArgumentException("Invalid root file specified", e);
-                    }
-                }
-            }, context);
-        } else try {
-            rootUrl = root.getAbsoluteFile().toURI().toURL();
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Invalid root file specified", e);
-        }
-        this.context = context;
-        codeSource = new CodeSource(rootUrl, (CodeSigner[])null);
-    }
-
-    private static Manifest readManifestFile(final File manifestFile) {
-        try {
-            if (manifestFile.isFile()) {
-                try (FileInputStream fis = new FileInputStream(manifestFile)) {
-                    return new Manifest(fis);
-                }
-            }
-        } catch (IOException e) {
-        }
-        return null;
-    }
-
-    public String getRootName() {
-        return rootName;
-    }
-
-    public ClassSpec getClassSpec(final String fileName) throws IOException {
-        final SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            try {
-                return doPrivileged(new PrivilegedExceptionAction<ClassSpec>() {
-                    public ClassSpec run() throws IOException {
-                        return doGetClassSpec(fileName);
-                    }
-                }, context);
-            } catch (PrivilegedActionException e) {
-                try {
-                    throw e.getException();
-                } catch (IOException e1) {
-                    throw e1;
-                } catch (RuntimeException e1) {
-                    throw e1;
-                } catch (Exception e1) {
-                    throw new UndeclaredThrowableException(e1);
-                }
-            }
-        } else {
-            return doGetClassSpec(fileName);
-        }
-    }
-
-    private ClassSpec doGetClassSpec(final String fileName) throws IOException {
-        final File file = new File(getRoot(), fileName);
-        if (! file.exists()) {
-            return null;
-        }
-        final long size = file.length();
-        final ClassSpec spec = new ClassSpec();
-        spec.setCodeSource(codeSource);
-        final InputStream is = new FileInputStream(file);
-        try {
-            if (size <= (long) Integer.MAX_VALUE) {
-                final int castSize = (int) size;
-                byte[] bytes = new byte[castSize];
-                int a = 0, res;
-                while ((res = is.read(bytes, a, castSize - a)) > 0) {
-                    a += res;
-                }
-                // done
-                is.close();
-                spec.setBytes(bytes);
-                return spec;
-            } else {
-                throw new IOException("Resource is too large to be a valid class file");
-            }
-        } finally {
-            StreamUtil.safeClose(is);
-        }
-    }
-
-    public PackageSpec getPackageSpec(final String name) throws IOException {
-        final SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            try {
-                return doPrivileged(new PrivilegedExceptionAction<PackageSpec>() {
-                    public PackageSpec run() throws IOException {
-                        return getPackageSpec(name, manifest, getRoot().toURI().toURL());
-                    }
-                }, context);
-            } catch (PrivilegedActionException e) {
-                try {
-                    throw e.getException();
-                } catch (IOException e1) {
-                    throw e1;
-                } catch (RuntimeException e1) {
-                    throw e1;
-                } catch (Exception e1) {
-                    throw new UndeclaredThrowableException(e1);
-                }
-            }
-        } else {
-            return getPackageSpec(name, manifest, getRoot().toURI().toURL());
-        }
-    }
-
-    public Resource getResource(final String name) {
-        final String canonPath = PathUtils.canonicalize(PathUtils.relativize(name));
-        final File file = new File(getRoot(), canonPath);
-        final SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            return doPrivileged(new PrivilegedAction<Resource>() {
-                public Resource run() {
-                    if (!file.exists()) {
-                        return null;
-                    } else {
-                        try {
-                            return new FileEntryResource(canonPath, file, file.toURI().toURL(), context);
-                        } catch (MalformedURLException e) {
-                            return null;
-                        }
-                    }
-                }
-            }, context);
-        } else if (! file.exists()) {
-            return null;
-        } else {
-            try {
-                return new FileEntryResource(canonPath, file, file.toURI().toURL(), context);
-            } catch (MalformedURLException e) {
-                return null;
-            }
-        }
-    }
-
-    class Itr implements Iterator<Resource> {
-        private final String base;
-        private final String[] names;
-        private final boolean recursive;
-        private int i = 0;
-        private Itr nested;
-        private Resource next;
-
-        Itr(final String base, final String[] names, final boolean recursive) {
-            assert PathUtils.isRelative(base);
-            assert names != null && names.length > 0;
-            this.base = base;
-            this.names = names;
-            this.recursive = recursive;
-        }
-
-        public boolean hasNext() {
-            final String[] names = this.names;
-            if (next != null) {
-                return true;
-            }
-            final String base = this.base;
-            while (i < names.length) {
-                final String current = names[i];
-                final String full = base.isEmpty() ? current : base + "/" + current;
-                final File file = new File(getRoot(), full);
-                if (recursive && nested == null) {
-                    final String[] children = file.list();
-                    if (children != null && children.length > 0) {
-                        nested = new Itr(full, children, recursive);
-                    }
-                }
-                if (nested != null) {
-                    if (nested.hasNext()) {
-                        next = nested.next();
-                        return true;
-                    }
-                    nested = null;
-                }
-                i++;
-                if (file.isFile()) {
-                    try {
-                        next = new FileEntryResource(full, file, file.toURI().toURL(), context);
-                        return true;
-                    } catch (MalformedURLException ignored) {
-                    }
-                }
-            }
-            return false;
-        }
-
-        public Resource next() {
-            if (! hasNext()) {
-                throw new NoSuchElementException();
-            }
-            try {
-                return next;
-            } finally {
-                next = null;
-            }
-        }
-
-        public void remove() {
-        }
-    }
-
-    public Iterator<Resource> iterateResources(final String startPath, final boolean recursive) {
-        final String canonPath = PathUtils.canonicalize(PathUtils.relativize(startPath));
-        final File start = new File(getRoot(), canonPath);
-        final String[] children = start.list();
-        if (children == null || children.length == 0) {
-            return Collections.<Resource>emptySet().iterator();
-        }
-        return new Itr(canonPath, children, recursive);
+        super(rootName, root.toPath(), context);
     }
 
     public Collection<String> getPaths() {
-        final List<String> index = new ArrayList<String>();
-        final File indexFile = new File(getRoot().getPath() + ".index");
+        new ArrayList<String>();
+        final Path indexFile = root.resolveSibling(root.getFileName() + ".index");
         if (ResourceLoaders.USE_INDEXES) {
             // First check for an index file
-            if (indexFile.exists()) {
+            if (Files.exists(indexFile)) {
                 try {
-                    final BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(indexFile)));
-                    try {
-                        String s;
-                        while ((s = r.readLine()) != null) {
-                            index.add(s.trim());
-                        }
-                        return index;
-                    } finally {
-                        // if exception is thrown, undo index creation
-                        r.close();
-                    }
+                    return Files.readAllLines(indexFile);
                 } catch (IOException e) {
-                    index.clear();
+                    // Do nothing
                 }
             }
         }
-        // Manually build index, starting with the root path
-        index.add("");
-        buildIndex(index, getRoot(), "");
+
+        // Manually build index
+        final Collection<String> index = super.getPaths();
+
         if (ResourceLoaders.WRITE_INDEXES) {
             // Now try to write it
-            boolean ok = false;
             try {
-                final FileOutputStream fos = new FileOutputStream(indexFile);
+                Files.write(indexFile, index);
+            } catch (Exception e) {
+                // well, we tried...
                 try {
-                    final OutputStreamWriter osw = new OutputStreamWriter(fos);
-                    try {
-                        final BufferedWriter writer = new BufferedWriter(osw);
-                        try {
-                            for (String name : index) {
-                                writer.write(name);
-                                writer.write('\n');
-                            }
-                            writer.close();
-                            osw.close();
-                            fos.close();
-                            ok = true;
-                        } finally {
-                            StreamUtil.safeClose(writer);
-                        }
-                    } finally {
-                        StreamUtil.safeClose(osw);
-                    }
-                } finally {
-                    StreamUtil.safeClose(fos);
-                }
-            } catch (IOException e) {
-                // failed, ignore
-            } finally {
-                if (! ok) {
-                    // well, we tried...
-                    indexFile.delete();
+                    Files.deleteIfExists(indexFile);
+                } catch (IOException ignored) {
+                    // Do nothing
                 }
             }
         }
         return index;
-    }
-
-    public URI getLocation() {
-        return getRoot().toURI();
-    }
-
-    private void buildIndex(final List<String> index, final File root, final String pathBase) {
-        File[] files = root.listFiles();
-        if (files != null) for (File file : files) {
-            if (file.isDirectory()) {
-                index.add(pathBase + file.getName());
-                buildIndex(index, file, pathBase + file.getName() + "/");
-            }
-        }
     }
 }

--- a/src/main/java/org/jboss/modules/PathResourceLoader.java
+++ b/src/main/java/org/jboss/modules/PathResourceLoader.java
@@ -19,11 +19,18 @@ package org.jboss.modules;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.AccessControlContext;
+import java.security.AccessController;
 import java.security.CodeSigner;
 import java.security.CodeSource;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -35,44 +42,59 @@ import java.util.stream.Collectors;
  *
  * @author <a href="mailto:bsideup@gmail.com">Sergei Egorov</a>
  */
-final class PathResourceLoader extends AbstractResourceLoader implements IterableResourceLoader {
+class PathResourceLoader extends AbstractResourceLoader implements IterableResourceLoader {
 
     private final String rootName;
-    private final Path root;
+    protected final Path root;
+    protected final AccessControlContext context;
 
     private final Manifest manifest;
     private final CodeSource codeSource;
 
-    PathResourceLoader(final String rootName, final Path root) {
+    PathResourceLoader(final String rootName, final Path root, final AccessControlContext context) {
         if (rootName == null) {
             throw new IllegalArgumentException("rootName is null");
         }
         if (root == null) {
             throw new IllegalArgumentException("root is null");
         }
+        if (context == null) {
+            throw new IllegalArgumentException("context is null");
+        }
         this.rootName = rootName;
         this.root = root;
+        this.context = context;
         final Path manifestFile = root.resolve("META-INF").resolve("MANIFEST.MF");
         manifest = readManifestFile(manifestFile);
 
         try {
-            codeSource = new CodeSource(root.toUri().toURL(), (CodeSigner[]) null);
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Invalid root file specified", e);
+            codeSource = doPrivilegedIfNeeded(context, () -> new CodeSource(root.toUri().toURL(), (CodeSigner[]) null));
+        } catch (UndeclaredThrowableException e) {
+            if (e.getUndeclaredThrowable() instanceof MalformedURLException) {
+                throw new IllegalArgumentException("Invalid root file specified", e);
+            } else {
+                throw e;
+            }
         }
     }
 
-    private static Manifest readManifestFile(final Path manifestFile) {
-        if (Files.isDirectory(manifestFile)) {
-            return null;
-        }
-
+    private Manifest readManifestFile(final Path manifestFile) {
         try {
-            try (InputStream is = Files.newInputStream(manifestFile)) {
-                return new Manifest(is);
+            return doPrivilegedIfNeeded(context, () -> {
+                if (Files.isDirectory(manifestFile)) {
+                    return null;
+                }
+
+                try (InputStream is = Files.newInputStream(manifestFile)) {
+                    return new Manifest(is);
+                }
+            });
+        } catch (UndeclaredThrowableException e) {
+            if (e.getUndeclaredThrowable() instanceof IOException) {
+                return null;
+            } else {
+                throw e;
             }
-        } catch (IOException e) {
-            return null;
         }
     }
 
@@ -82,31 +104,63 @@ final class PathResourceLoader extends AbstractResourceLoader implements Iterabl
     }
 
     @Override
+    public String getLibrary(String name) {
+        final String mappedName = System.mapLibraryName(name);
+        for (String path : NativeLibraryResourceLoader.Identification.NATIVE_SEARCH_PATHS) {
+            Path testFile = root.resolve(path).resolve(mappedName);
+            if (Files.exists(testFile)) {
+                return testFile.toAbsolutePath().toString();
+            }
+        }
+        return null;
+    }
+
+    @Override
     public ClassSpec getClassSpec(final String fileName) throws IOException {
         final Path file = root.resolve(fileName);
-        if (!Files.exists(file)) {
-            return null;
+
+        try {
+            return doPrivilegedIfNeeded(context, () -> {
+                if (!Files.exists(file)) {
+                    return null;
+                }
+                final ClassSpec spec = new ClassSpec();
+                spec.setCodeSource(codeSource);
+                spec.setBytes(Files.readAllBytes(file));
+                return spec;
+            });
+        } catch (UndeclaredThrowableException e) {
+            if (e.getUndeclaredThrowable() instanceof IOException) {
+                throw (IOException) e.getUndeclaredThrowable();
+            } else {
+                throw e;
+            }
         }
-        final ClassSpec spec = new ClassSpec();
-        spec.setCodeSource(codeSource);
-        spec.setBytes(Files.readAllBytes(file));
-        return spec;
     }
 
     @Override
     public PackageSpec getPackageSpec(final String name) throws IOException {
-        return getPackageSpec(name, manifest, root.toUri().toURL());
+        try {
+            URL rootUrl = doPrivilegedIfNeeded(context, () -> root.toUri().toURL());
+            return getPackageSpec(name, manifest, rootUrl);
+        } catch (UndeclaredThrowableException e) {
+            if (e.getUndeclaredThrowable() instanceof IOException) {
+                throw (IOException) e.getUndeclaredThrowable();
+            } else {
+                throw e;
+            }
+        }
     }
 
     @Override
     public Resource getResource(final String name) {
         final Path file = root.resolve(PathUtils.canonicalize(PathUtils.relativize(name)));
 
-        if (!Files.exists(file)) {
+        if (!doPrivilegedIfNeeded(context, () -> Files.exists(file))) {
             return null;
-        } else {
-            return new PathResource(file);
         }
+
+        return new PathResource(file, context);
     }
 
     @Override
@@ -116,7 +170,7 @@ final class PathResourceLoader extends AbstractResourceLoader implements Iterabl
             return Files.walk(path, recursive ? Integer.MAX_VALUE : 1)
                     .filter(it -> !Files.isDirectory(it))
                     .map(root::relativize)
-                    .<Resource>map(PathResource::new)
+                    .<Resource>map(resourcePath -> new PathResource(resourcePath, context))
                     .iterator();
         } catch (IOException e) {
             return Collections.emptyIterator();
@@ -127,22 +181,55 @@ final class PathResourceLoader extends AbstractResourceLoader implements Iterabl
     public Collection<String> getPaths() {
         try {
             final String separator = root.getFileSystem().getSeparator();
-            return Files.walk(root)
-                    .filter(Files::isDirectory)
-                    .map(dir -> {
-                        final String result = root.relativize(dir).toString();
 
-                        // JBoss modules expect folders not to end with a slash, so we have to strip it.
-                        if (result.endsWith(separator)) {
-                            return result.substring(0, result.length() - separator.length());
-                        } else {
-                            return result;
-                        }
-                    })
-                    .collect(Collectors.toList());
-        } catch (IOException e) {
-            // do nothing
-            return Collections.emptyList();
+            return doPrivilegedIfNeeded(context, () -> {
+                return Files.walk(root)
+                        .filter(Files::isDirectory)
+                        .map(dir -> {
+                            final String result = root.relativize(dir).toString();
+
+                            // JBoss modules expect folders not to end with a slash, so we have to strip it.
+                            if (result.endsWith(separator)) {
+                                return result.substring(0, result.length() - separator.length());
+                            } else {
+                                return result;
+                            }
+                        })
+                        .collect(Collectors.toList());
+            });
+        } catch (UndeclaredThrowableException e) {
+            if (e.getUndeclaredThrowable() instanceof IOException) {
+                return Collections.emptyList();
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public URI getLocation() {
+        return doPrivilegedIfNeeded(context, root::toUri);
+    }
+
+    static <T> T doPrivilegedIfNeeded(AccessControlContext context, PrivilegedExceptionAction<T> action) {
+        SecurityManager sm = System.getSecurityManager();
+
+        if (sm == null) {
+            try {
+                return action.run();
+            } catch (Exception e) {
+                throw new UndeclaredThrowableException(e);
+            }
+        } else {
+            try {
+                return AccessController.doPrivileged(action, context);
+            } catch (PrivilegedActionException e) {
+                try {
+                    throw e.getException();
+                } catch (Exception e1) {
+                    throw new UndeclaredThrowableException(e1);
+                }
+            }
         }
     }
 }

--- a/src/main/java/org/jboss/modules/ResourceLoaders.java
+++ b/src/main/java/org/jboss/modules/ResourceLoaders.java
@@ -136,6 +136,6 @@ public final class ResourceLoaders {
      * @return the resource loader
      */
     public static IterableResourceLoader createPathResourceLoader(final String name, final Path path) {
-        return new PathResourceLoader(name, path);
+        return new PathResourceLoader(name, path, AccessController.getContext());
     }
 }


### PR DESCRIPTION
Since #97 was merged, `FileResourceLoader` is no more and could be replaced with `PathResourceLoader` + `File#toPath()`. Only one thing left in FileResourceLoader - index caching, which IMO shouldn't be a part of PathResourceLoader because NIO2 FS might be read-only.



I agree to the terms of the MIT license.