### PR TITLE
MODULE-279 - Support settings.xml <proxies>

### DIFF
--- a/src/main/java/org/jboss/modules/maven/MavenArtifactUtil.java
+++ b/src/main/java/org/jboss/modules/maven/MavenArtifactUtil.java
@@ -158,7 +158,7 @@ public final class MavenArtifactUtil {
             return;
         }
         final URL url = new URL(src);
-        final URLConnection connection = url.openConnection();
+        final URLConnection connection = MavenSettings.getSettings().openConnection(url);
         boolean message = Boolean.getBoolean("maven.download.message");
 
         try (InputStream bis = connection.getInputStream()){

--- a/src/main/java/org/jboss/modules/maven/MavenSettings.java
+++ b/src/main/java/org/jboss/modules/maven/MavenSettings.java
@@ -18,6 +18,31 @@
 
 package org.jboss.modules.maven;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+import org.jboss.modules.xml.MXParser;
+import org.jboss.modules.xml.XmlPullParser;
+import org.jboss.modules.xml.XmlPullParserException;
+
 import static org.jboss.modules.maven.MavenArtifactUtil.doIo;
 import static org.jboss.modules.xml.ModuleXmlParser.endOfDocument;
 import static org.jboss.modules.xml.ModuleXmlParser.unexpectedContent;
@@ -25,22 +50,6 @@ import static org.jboss.modules.xml.XmlPullParser.END_DOCUMENT;
 import static org.jboss.modules.xml.XmlPullParser.END_TAG;
 import static org.jboss.modules.xml.XmlPullParser.FEATURE_PROCESS_NAMESPACES;
 import static org.jboss.modules.xml.XmlPullParser.START_TAG;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
-import org.jboss.modules.xml.MXParser;
-import org.jboss.modules.xml.XmlPullParser;
-import org.jboss.modules.xml.XmlPullParserException;
 
 /**
  * @author Tomaz Cerar (c) 2014 Red Hat Inc.
@@ -51,9 +60,14 @@ final class MavenSettings {
     private static volatile MavenSettings mavenSettings;
 
     private Path localRepository = null;
+
     private final List<String> remoteRepositories = new LinkedList<>();
+
     private final Map<String, Profile> profiles = new HashMap<>();
+
     private final List<String> activeProfileNames = new LinkedList<>();
+
+    private final List<Proxy> proxies = new ArrayList<>();
 
     MavenSettings() {
         configureDefaults();
@@ -70,8 +84,17 @@ final class MavenSettings {
             return mavenSettings = doIo(() -> {
                 MavenSettings settings = new MavenSettings();
 
+                Path settingsPath = null;
+
+                if ( System.getProperty( "jboss.modules.settings.xml.url" ) != null ) {
+                    settingsPath = Paths.get( new URL(System.getProperty( "jboss.modules.settings.xml.url")).toURI());
+                }
+
                 Path m2 = Paths.get(System.getProperty("user.home"), ".m2");
-                Path settingsPath = m2.resolve("settings.xml");
+
+                if ( settingsPath == null ) {
+                    settingsPath = m2.resolve("settings.xml");
+                }
 
                 if (Files.notExists(settingsPath)) {
                     String mavenHome = System.getenv("M2_HOME");
@@ -138,6 +161,20 @@ final class MavenSettings {
                             }
                             break;
                         }
+                        case "proxies": {
+                            while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+                                if (eventType == START_TAG) {
+                                    switch (reader.getName()) {
+                                        case "proxy": {
+                                            parseProxy(reader, mavenSettings);
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    break;
+                                }
+                            }
+                        }
                         case "profiles": {
                             while ((eventType = reader.nextTag()) != END_DOCUMENT) {
                                 if (eventType == START_TAG) {
@@ -182,6 +219,55 @@ final class MavenSettings {
             }
         }
         throw endOfDocument(reader);
+    }
+
+    static void parseProxy(final XmlPullParser reader, MavenSettings mavenSettings) throws XmlPullParserException, IOException {
+        int eventType;
+        Proxy proxy = new Proxy();
+        while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+            if (eventType == START_TAG) {
+                switch (reader.getName()) {
+                    case "id": {
+                        proxy.setId(reader.nextText());
+                        break;
+                    }
+                    case "active": {
+                        proxy.setActive(Boolean.parseBoolean(reader.nextText()));
+                        break;
+                    }
+                    case "protocol": {
+                        proxy.setProtocol(reader.nextText());
+                        break;
+                    }
+                    case "host": {
+                        proxy.setHost(reader.nextText());
+                        break;
+                    }
+                    case "port": {
+                        proxy.setPort(Integer.parseInt(reader.nextText()));
+                        break;
+                    }
+                    case "username": {
+                        proxy.setUsername(reader.nextText());
+                        break;
+                    }
+                    case "password": {
+                        proxy.setPassword(reader.nextText());
+                        break;
+                    }
+                    case "nonProxyHosts": {
+                        proxy.setNonProxyHosts(reader.nextText());
+                        break;
+                    }
+                    default: {
+                        skip(reader);
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+        mavenSettings.addProxy(proxy);
     }
 
     static void parseProfile(final XmlPullParser reader, MavenSettings mavenSettings) throws XmlPullParserException, IOException {
@@ -302,6 +388,45 @@ final class MavenSettings {
         activeProfileNames.add(profileName);
     }
 
+    public void addProxy(Proxy proxy) {
+        this.proxies.add(proxy);
+    }
+
+    public List<Proxy> getProxies() {
+        return this.proxies;
+    }
+
+    public Proxy getProxyFor(URL url) {
+        for (Proxy proxy : this.proxies) {
+            if (proxy.canProxyFor(url)) {
+                return proxy;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Opens a connection with appropriate proxy and credentials, if required.
+     *
+     * @param url The URL to open.
+     * @return The opened connection.
+     * @throws IOException If an error occurs establishing the connection.
+     */
+    public URLConnection openConnection(URL url) throws IOException {
+        Proxy proxy = getProxyFor(url);
+        URLConnection conn = null;
+
+        if (proxy != null) {
+            conn = url.openConnection(proxy.getProxy());
+            proxy.authenticate(conn);
+        } else {
+            conn = url.openConnection();
+        }
+
+        return conn;
+    }
+
     void resolveActiveSettings() {
         for (String name : activeProfileNames) {
             Profile p = profiles.get(name);
@@ -311,9 +436,143 @@ final class MavenSettings {
         }
     }
 
+    static final class Proxy {
+        private String id;
+
+        private boolean active = true;
+
+        private String protocol = "http";
+
+        private String host;
+
+        private int port;
+
+        private String username;
+
+        private String password;
+
+        private Set<NonProxyHost> nonProxyHosts = new HashSet<>();
+
+        private AtomicReference<java.net.Proxy> netProxy = new AtomicReference<>();
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public void setActive(boolean active) {
+            this.active = active;
+        }
+
+        public String getProtocol() {
+            return protocol;
+        }
+
+        public void setProtocol(String protocol) {
+            this.protocol = protocol;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public void setHost(String host) {
+            this.host = host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+
+        public void setNonProxyHosts(String nonProxyHosts) {
+            String[] specs = nonProxyHosts.split("\\|");
+            this.nonProxyHosts.clear();
+            for (String spec : specs) {
+                this.nonProxyHosts.add(new NonProxyHost(spec));
+            }
+        }
+
+        public boolean canProxyFor(URL url) {
+            for (NonProxyHost nonProxyHost : this.nonProxyHosts) {
+                if (nonProxyHost.matches(url)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public java.net.Proxy getProxy() {
+            return this.netProxy.updateAndGet(proxy -> {
+                if (proxy == null) {
+                    proxy = new java.net.Proxy(java.net.Proxy.Type.HTTP,
+                                               new InetSocketAddress(getHost(), getPort()));
+                }
+
+                return proxy;
+            });
+        }
+
+        public String getCredentialsBase64() {
+            Base64.Encoder encoder = Base64.getEncoder();
+            return encoder.encodeToString((this.username + ":" + this.password).getBytes());
+        }
+
+        public void authenticate(URLConnection conn) {
+            if (this.username == null && this.password == null) {
+                return;
+            }
+            String authz = "Basic " + getCredentialsBase64();
+            conn.addRequestProperty("Proxy-Authorization", authz);
+        }
+    }
+
+    static final class NonProxyHost {
+        private final Pattern pattern;
+
+        NonProxyHost(String spec) {
+
+            spec = spec.replace(".", "\\.");
+            spec = spec.replace("*", ".*");
+            spec = "^" + spec + "$";
+            this.pattern = Pattern.compile(spec);
+        }
+
+        boolean matches(URL url) {
+            return this.pattern.matcher(url.getHost()).matches();
+        }
+    }
 
     static final class Profile {
         private String id;
+
         final List<String> repositories = new LinkedList<>();
 
         Profile() {

--- a/src/test/java/org/jboss/modules/MavenResourceTest.java
+++ b/src/test/java/org/jboss/modules/MavenResourceTest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.jboss.modules.maven.ArtifactCoordinates;
 import org.jboss.modules.maven.MavenArtifactUtil;
+import org.jboss.modules.maven.MavenSettingsTest;
 import org.jboss.modules.util.Util;
 import org.junit.Assert;
 import org.junit.Before;
@@ -38,6 +39,7 @@ import org.junit.rules.TemporaryFolder;
 public class MavenResourceTest {
 
     protected static final ModuleIdentifier MODULE_ID = ModuleIdentifier.fromString("test.maven");
+
     protected static final ModuleIdentifier MODULE_ID2 = ModuleIdentifier.fromString("test.maven:non-main");
 
     @Rule
@@ -68,11 +70,16 @@ public class MavenResourceTest {
 
     @Test
     public void testDefaultRepositories() throws Exception {
-        Module module = moduleLoader.loadModule(MODULE_ID2);
-        URL url = module.getResource("org/jboss/resteasy/plugins/providers/jackson/ResteasyJacksonProvider.class");
-        System.out.println(url);
-        Assert.assertNotNull(url);
-
+        try {
+            URL settingsXmlUrl = MavenSettingsTest.class.getResource("jboss-settings.xml");
+            System.setProperty("jboss.modules.settings.xml.url", settingsXmlUrl.toExternalForm());
+            Module module = moduleLoader.loadModule(MODULE_ID2);
+            URL url = module.getResource("org/jboss/resteasy/plugins/providers/jackson/ResteasyJacksonProvider.class");
+            System.out.println(url);
+            Assert.assertNotNull(url);
+        } finally {
+            System.clearProperty("jboss.modules.settings.xml.url");
+        }
     }
 
     /**

--- a/src/test/java/org/jboss/modules/maven/NonProxyHostTest.java
+++ b/src/test/java/org/jboss/modules/maven/NonProxyHostTest.java
@@ -1,0 +1,30 @@
+package org.jboss.modules.maven;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Created by bob on 4/21/17.
+ */
+public class NonProxyHostTest {
+
+    @Test
+    public void testExactMatch() throws MalformedURLException {
+        MavenSettings.NonProxyHost nph = new MavenSettings.NonProxyHost("www.google.com");
+        Assert.assertTrue(nph.matches(new URL("http://www.google.com/")));
+        Assert.assertFalse(nph.matches(new URL("http://google.com/")));
+        Assert.assertFalse(nph.matches(new URL("http://www.apple.com/")));
+    }
+
+    @Test
+    public void testWildcardMatch() throws MalformedURLException {
+        MavenSettings.NonProxyHost nph = new MavenSettings.NonProxyHost("*.google.com");
+        Assert.assertTrue(nph.matches(new URL("http://www.google.com/")));
+        Assert.assertTrue(nph.matches(new URL("http://wave.google.com/")));
+        Assert.assertFalse(nph.matches(new URL("http://google.com/")));
+        Assert.assertFalse(nph.matches(new URL("http://www.apple.com/")));
+    }
+}

--- a/src/test/resources/org/jboss/modules/maven/jboss-settings.xml
+++ b/src/test/resources/org/jboss/modules/maven/jboss-settings.xml
@@ -5,19 +5,6 @@
 
   <localRepository/>
 
-  <proxies>
-    <proxy>
-      <id>my-proxy</id>
-      <active>true</active>
-      <host>myproxy.corp.com</host>
-      <port>8080</port>
-      <protocol>http</protocol>
-      <username>bob</username>
-      <password>hunter2</password>
-      <nonProxyHosts>www.google.com|*.apple.com</nonProxyHosts>
-    </proxy>
-  </proxies>
-
   <profiles>
     <profile>
       <id>jboss-public-repository</id>


### PR DESCRIPTION
Motivation:

Since jboss-modules can resolve artifacts at run-time, and it does a
passable job of using the user's settings.xml, it should support other
aspects related to fetching, such as <proxies>.

Changes:

Parsing in the <proxies> block, matching wildcards for non-proxy-hosts,
and producing the correct java.net.Proxy (or Proxy.NO_PROXY) when asked
for an appropriate proxy when attempting to download an artifact.

Additionally, support system property jboss.modules.settings.xml.url
in order to facilitate testing that requires particular settings.xml
contents when using the MavenSettings.getSettings() static accessor
implicitly to resolve artifacts.

Result:

Proxies are used, if configured.