### PR TITLE
MODULES-290 deduplicate lists of loaders to save memory

### DIFF
--- a/src/main/java/org/jboss/modules/Linkage.java
+++ b/src/main/java/org/jboss/modules/Linkage.java
@@ -58,7 +58,7 @@ final class Linkage {
         this.dependencySpecs = dependencySpecs;
         this.dependencies = dependencies;
         this.state = state;
-        this.allPaths = allPaths;
+        this.allPaths = PathUtils.deduplicateLists(allPaths);
     }
 
     Map<String, List<LocalLoader>> getPaths() {

--- a/src/main/java/org/jboss/modules/PathUtils.java
+++ b/src/main/java/org/jboss/modules/PathUtils.java
@@ -24,10 +24,15 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+
 import org.jboss.modules.filter.PathFilter;
 
 /**
@@ -267,5 +272,32 @@ public final class PathUtils {
     public static boolean isSeparator(final char ch) {
         // the second half of this compare will optimize away on / OSes
         return ch == '/' || File.separatorChar != '/' && ch == File.separatorChar;
+    }
+
+    /**
+     * Takes a list of maps an returns an immutable representation of the same map, with all duplicate lists
+     * coalesced into a single object, and with all lists replaced by immutable array lists that has a backing array
+     * that is the correct size for the number of contents.
+     *
+     * This can result in a significant memory saving for some use cases
+     *
+     */
+    static <T> Map<String, List<T>> deduplicateLists(Map<String, List<T>> allPaths) {
+        if (allPaths == null) {
+            return null;
+        } else if (allPaths.size() == 0) {
+            return Collections.emptyMap();
+        } else {
+            Map<String, List<T>> newPaths = new HashMap<>();
+            Map<List<T>, List<T>> dedup = new HashMap<>();
+            for (Map.Entry<String, List<T>> e : allPaths.entrySet()) {
+                List<T> l = dedup.get(e.getValue());
+                if (l == null) {
+                    dedup.put(e.getValue(), l = Collections.unmodifiableList(new ArrayList<>(e.getValue())));
+                }
+                newPaths.put(e.getKey(), l);
+            }
+            return Collections.unmodifiableMap(newPaths);
+        }
     }
 }

--- a/src/main/java/org/jboss/modules/Paths.java
+++ b/src/main/java/org/jboss/modules/Paths.java
@@ -35,7 +35,7 @@ final class Paths<T, A> {
 
     Paths(final A[] sourceList, final Map<String, List<T>> allPaths) {
         this.sourceList = sourceList;
-        this.allPaths = allPaths;
+        this.allPaths = PathUtils.deduplicateLists(allPaths);
     }
 
     Map<String, List<T>> getAllPaths() {


### PR DESCRIPTION
This results in a saving or approximately 3mb of heap in Wildfly (I see baseline memory usage for standalone.xml dropping from 27mb to 24mb).