### PR TITLE
MODULES-260 fix how security provider loading is done + make it work …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>21</version>
+        <version>24</version>
     </parent>
 
     <licenses>

--- a/src/main/java/org/jboss/modules/Main.java
+++ b/src/main/java/org/jboss/modules/Main.java
@@ -29,11 +29,7 @@ import java.io.PrintWriter;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
-import java.security.AccessControlContext;
 import java.security.Policy;
-import java.security.PrivilegedAction;
-import java.security.ProtectionDomain;
-import java.security.Provider;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -495,15 +491,7 @@ public final class Main {
             ManagementFactory.getPlatformMBeanServer();
         }
 
-        final ServiceLoader<Provider> providerServiceLoader = ServiceLoader.load(Provider.class, bootClassLoader);
-        for (Provider provider : providerServiceLoader) {
-            final Class<? extends Provider> providerClass = provider.getClass();
-            // each provider needs permission to install itself
-            doPrivileged((PrivilegedAction<Void>) () -> {
-                Security.addProvider(provider);
-                return null;
-            }, new AccessControlContext(new ProtectionDomain[] { providerClass.getProtectionDomain() }));
-        }
+        Security.getProviders();//force loading security providers
 
         ModuleLoader.installMBeanServer();
 


### PR DESCRIPTION
…on JDK9b175

Security.getProviders() honors java.security jvm configuration about the order & what providers to enable.
forcing with with service loader loads it in non deterministic order as well as can result in additional providers that need special configuration as for example SunDeploy-MozillaJSS