### PR TITLE
MODULES-303 - Interpolate ${props} in settings.xml

### DIFF
--- a/src/test/java/org/jboss/modules/maven/MavenSettingsTest.java
+++ b/src/test/java/org/jboss/modules/maven/MavenSettingsTest.java
@@ -73,6 +73,23 @@ public class MavenSettingsTest {
 
     }
 
+    @Test
+    public void testInterpolatedLocalRepo() throws Exception {
+        Path userRepo = tmpdir.newFolder(".m2", "repository").toPath();
+        String userHome = System.getProperty("user.home");
+        System.setProperty("user.home", tmpdir.getRoot().getAbsolutePath());
+
+        try {
+            clearCachedSettings();
+            MavenSettings settings = new MavenSettings();
+
+            MavenSettings.parseSettingsXml(Paths.get(MavenSettingsTest.class.getResource("settings-interpolated-local-repo.xml").toURI()), settings);
+            Assert.assertEquals(Paths.get(tmpdir.getRoot().getAbsolutePath() + "/.mvnrepository"), settings.getLocalRepository());
+        } finally {
+            System.setProperty("user.home", userHome);
+        }
+    }
+
 
     @Test
     public void testProxies() throws Exception {
@@ -130,5 +147,46 @@ public class MavenSettingsTest {
         ArtifactCoordinates coordinates = ArtifactCoordinates.fromString("org.wildfly.core:wildfly-version:2.0.5.Final-20151222.144931-1");
         String path = coordinates.relativeArtifactPath('/');
         Assert.assertEquals("org/wildfly/core/wildfly-version/2.0.5.Final-SNAPSHOT/wildfly-version-2.0.5.Final-20151222.144931-1", path);
+    }
+
+    @Test
+    public void testInterpolateVariablesOneVariable() throws Exception {
+        try {
+            System.setProperty( "test.user.home", "/home/bob" );
+            Assert.assertEquals("/home/bob/.m2/repository", MavenSettings.interpolateVariables("${test.user.home}/.m2/repository"));
+        } finally {
+            System.clearProperty("test.user.home");
+        }
+    }
+
+    @Test
+    public void testInterpolateVariablesTwoVariables() throws Exception {
+        try {
+            System.setProperty( "test.user.home", "/home/bob" );
+            System.setProperty( "test.repo.dir", "repository" );
+            Assert.assertEquals("/home/bob/.m2/repository", MavenSettings.interpolateVariables("${test.user.home}/.m2/${test.repo.dir}"));
+        } finally {
+            System.clearProperty("test.user.home");
+        }
+    }
+
+    @Test
+    public void testInterpolateVariablesInvalidExpression() throws Exception {
+        try {
+            System.setProperty( "test.user.home", "/home/bob" );
+            Assert.assertEquals("${test.user.home/.m2/repository", MavenSettings.interpolateVariables("${test.user.home/.m2/repository"));
+        } finally {
+            System.clearProperty("test.user.home");
+        }
+    }
+
+    @Test
+    public void testInterpolateVariablesInvalidExpression2() throws Exception {
+        try {
+            System.setProperty( "test.user.home", "/home/bob" );
+            Assert.assertEquals("/home/bob/.m2/${repoName", MavenSettings.interpolateVariables("${test.user.home}/.m2/${repoName"));
+        } finally {
+            System.clearProperty("test.user.home");
+        }
     }
 }

--- a/src/test/resources/org/jboss/modules/maven/settings-interpolated-local-repo.xml
+++ b/src/test/resources/org/jboss/modules/maven/settings-interpolated-local-repo.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/settings/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+
+  <localRepository>${user.home}/.mvnrepository</localRepository>
+  <profiles>
+    <profile>
+      <id>jboss-public-repository</id>
+      <repositories>
+
+
+        <repository>
+          <id>jboss-public-repository-group</id>
+          <name>JBoss Public Maven Repository Group</name>
+          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+
+        <repository>
+          <id>jboss-developer-repository-group</id>
+          <name>JBoss Developer Maven Repository Group</name>
+          <url>https://repository.jboss.org/nexus/content/groups/developer/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+
+
+    </profile>
+    <profile>
+      <id>eap-repo</id>
+      <repositories>
+        <repository>
+          <id>brew-maven-repo</id>
+          <name>Red Hat Brew repo</name>
+          <url>http://download.lab.bos.redhat.com/brewroot/repos/jb-eap-6-rhel-6-build/latest/maven/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>brew-maven-repo</id>
+          <name>Red Hat Brew repo</name>
+          <url>http://download.lab.bos.redhat.com/brewroot/repos/jb-eap-6-rhel-6-build/latest/maven/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+
+
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>jboss-public-repository</activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
Since settings.xml can use ${props} and ${env.ENV} within
the `<localRepository>` tag, we should interpolate them if they
are present.