### PR TITLE
Fixes the link to the documentation current location

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ JBoss Modules is designed to work with any existing library or application witho
 
 ## Documentation
 
-All documentation lives at https://docs.jboss.org/author/display/MODULES/Home
+All documentation lives at https://jboss-modules.github.io/jboss-modules/manual/
 
 ## Issue tracker
 


### PR DESCRIPTION
The documentation is currently on `github.io` and no longer on `jboss.org`. It seams that this updating the link here, has been forgotten.