### PR TITLE
[MODULES-324] Fixing race condition

### DIFF
--- a/src/main/java/org/jboss/modules/ModuleLoader.java
+++ b/src/main/java/org/jboss/modules/ModuleLoader.java
@@ -482,12 +482,7 @@ public class ModuleLoader {
             return futureModule.getModule();
         }
 
-        FutureModule newFuture = new FutureModule(name);
-        futureModule = moduleMap.putIfAbsent(name, newFuture);
-        if (futureModule != null) {
-            return futureModule.getModule();
-        }
-
+        final FutureModule newFuture = new FutureModule(name);
         boolean ok = false;
         try {
             final ModuleLogger log = Module.log;
@@ -501,6 +496,10 @@ public class ModuleLoader {
             }
             if (! moduleSpec.getName().equals(name)) {
                 throw new ModuleLoadException("Module loader found a module with the wrong name");
+            }
+            futureModule = moduleMap.putIfAbsent(name, newFuture);
+            if (futureModule != null) {
+                return futureModule.getModule();
             }
             final Module module;
             if (moduleSpec instanceof AliasModuleSpec) {


### PR DESCRIPTION
Module A depends on module B (optional dependency)
Both modules are dynamic, they're not present on the file system
but deployed at runtime. The following scenario is problematic:

 1] Module A is starting and module B is not available yet
 2] Module A during its initialization phase calls
    ModuleLoader.loadModuleLocal() to resolve its optional module B dependency
 3] Module A initialization thread registers "newFuture" with "moduleMap"
 4] Module A initialization thread fails to find ModuleSpec of module B
 5] ModuleLoadService representing Module B appears and is starting
    (such service knows all its preconditions are met - its ModuleSpec is available)
 6] MSC thread executing ModuleLoadService.start() (of module B)
    is calling moduleLoader.loadModule(moduleB_Id)
 7] MSC thread executing ModuleLoadService.start() (of module B)
    enters ModuleLoader.loadModuleLocal() to find the module
 8] MSC thread requests "moduleMap" and receives "newFuture" created in step [3]
 9] MSC thread enters "newFuture" wait set and blocks (waiting for Module A
    initialization thread to complete)
10] Module A initialization thread wakes up and identifies that (moduleSpec == null)
    MOduleLoader.loadModuleLocal() will return null
11] Before method return "finally" sections is executed, where:
    a) newFuture.setModule(null) is called
    b) "newFuture" is removed from "moduleMap"
12] MSC thread wakes up and throws ModuleNotFoundException

This fix ensures "newFuture" is associated with "moduleMap" iff "moduleSpec" exists.
This way it is guaranteed once dynamic module appears its module spec lookup will always succeed.