### PR TITLE
[MODULES-366] ModuleLoader.installMBeanServer is now public

### DIFF
--- a/src/main/java/org/jboss/modules/ModuleLoader.java
+++ b/src/main/java/org/jboss/modules/ModuleLoader.java
@@ -262,7 +262,10 @@ public class ModuleLoader {
         return version == null ? module.getName() : module.getName() + "@" + version;
     }
 
-    static void installMBeanServer() {
+    /**
+     * Installs this ModuleLoader as a JMX Managed bean.
+     */
+    public static void installMBeanServer() {
         REG_REF.installReal();
     }
 


### PR DESCRIPTION
Some frameworks need it:
- JBoss Forge: https://github.com/forge/furnace/blob/fc9c2dcd3c8706ae1f587c6c347b6b4387faead9/container/src/main/java/org/jboss/forge/furnace/impl/modules/AddonModuleLoader.java#L326-L338
- WildFly Swarm: https://github.com/wildfly-swarm/wildfly-swarm/blob/d16c244a4f3877396f0ff190f4fc355e14dcf501/core/container/src/main/java/org/wildfly/swarm/Swarm.java#L854-L862