### PR TITLE
[MODULES-375] Check if the artifact was successfully resolved before …

### DIFF
--- a/src/main/java/org/jboss/modules/xml/ModuleXmlParser.java
+++ b/src/main/java/org/jboss/modules/xml/ModuleXmlParser.java
@@ -1019,6 +1019,9 @@ public final class ModuleXmlParser {
                         try {
                             coordinates = ArtifactCoordinates.fromString(name);
                             final File file = mavenResolver.resolveJarArtifact(coordinates);
+                            if (file == null) {
+                                throw new XmlPullParserException(String.format("Failed to resolve artifact '%s'", coordinates), reader, null);
+                            }
                             resourceLoader = factory.createResourceLoader("", file.getPath(), name);
                         } catch (IOException | IllegalArgumentException e) {
                             throw new XmlPullParserException(String.format("Failed to add artifact '%s'", name), reader, e);


### PR DESCRIPTION
…attempting to create the loader.
https://issues.jboss.org/browse/MODULES-375

There doesn't seem to be a need for an upstream fix and the `ResourceLoader` is created in the `MavenArtifactUtil` which already checks for a `null` resolved artifact.