### PR TITLE
[JBEAP-15434] [MODULES-339] JAXP redirection fails on 8u161, also in embedded scenarios

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,40 @@
     <properties>
         <skip.compile>false</skip.compile>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <version.bridger>1.4.Final</version.bridger>
+
+        <jdk.min.version>9</jdk.min.version>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>java8-test-profile</id>
+            <activation>
+                <property>
+                    <name>java8.home</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>java8-test</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <jvm>${java8.home}/bin/java</jvm>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <build>
         <resources>
@@ -104,12 +135,46 @@
             </plugin>
             </plugins>
         </pluginManagement>
+
         <plugins>
             <!-- Compiler -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${version.compiler.plugin}</version>
+                <version>3.7.0-jboss-1</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>8</release>
+                            <buildDirectory>${project.build.directory}</buildDirectory>
+                            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${project.build.directory}/jdk-misc.jar</additionalClasspathElement>
+                            </additionalClasspathElements>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-java9</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>9</release>
+                            <buildDirectory>${project.build.directory}</buildDirectory>
+                            <compileSourceRoots>${project.basedir}/src/main/java9</compileSourceRoots>
+                            <outputDirectory>${project.build.directory}/classes/META-INF/versions/9</outputDirectory>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${project.build.outputDirectory}</additionalClasspathElement>
+                            </additionalClasspathElements>
+                        </configuration>
+                    </execution>
+                </executions>
                 <configuration>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
@@ -132,24 +197,14 @@
                     </includes>
                     <forkMode>always</forkMode>
                 </configuration>
-            </plugin>
-
-            <!-- Remote resources -->
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>add-java9-supplement</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
+                        <id>default-test</id>
                         <configuration>
-                            <includeGroupIds>org.jboss.modules</includeGroupIds>
-                            <includeArtifactIds>jboss-modules-jdk9-supplement</includeArtifactIds>
-                            <excludeTransitive>true</excludeTransitive>
-                            <includes>**/*.class</includes>
-                            <outputDirectory>${project.build.directory}/generated-resources/META-INF/versions/9</outputDirectory>
+                            <classesDirectory>${project.build.directory}/classes/META-INF/versions/9</classesDirectory>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${project.build.directory}/classes</additionalClasspathElement>
+                            </additionalClasspathElements>
                         </configuration>
                     </execution>
                 </executions>
@@ -182,21 +237,44 @@
                     <excludePackageNames>org.jboss.modules._private</excludePackageNames>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jboss.bridger</groupId>
+                <artifactId>bridger</artifactId>
+                <version>${version.bridger}</version>
+                <executions>
+                     <!-- run after "compile", runs bridger on main classes -->
+                     <execution>
+                         <id>weave</id>
+                         <phase>process-classes</phase>
+                         <goals>
+                             <goal>transform</goal>
+                         </goals>
+                     </execution>
+                </executions>
+            </plugin>
+
+            <!-- Dependency -->
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>fetch-misc</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>get</goal>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifact>org.jboss:jdk-misc:2.Final</artifact>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <stripVersion>true</stripVersion>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.modules</groupId>
-            <artifactId>jboss-modules-jdk9-supplement</artifactId>
-            <version>1.2.Final</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.modules</groupId>
-                    <artifactId>jboss-modules</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-impl-base</artifactId>

--- a/src/main/java/__redirected/ConstructorSupplier.java
+++ b/src/main/java/__redirected/ConstructorSupplier.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.function.Supplier;
+
+final class ConstructorSupplier<T> implements Supplier<T> {
+    private final Constructor<? extends T> constructor;
+
+    ConstructorSupplier(final Constructor<? extends T> constructor) {
+        this.constructor = constructor;
+    }
+
+    public T get() {
+        try {
+            return constructor.newInstance();
+        } catch (InstantiationException e) {
+            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
+        } catch (IllegalAccessException e) {
+            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
+        } catch (InvocationTargetException e) {
+            throw __RedirectedUtils.rethrowCause(e);
+        }
+    }
+}

--- a/src/main/java/__redirected/JDKSpecific.java
+++ b/src/main/java/__redirected/JDKSpecific.java
@@ -1,0 +1,245 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.function.Supplier;
+
+import javax.xml.XMLConstants;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.xpath.XPathFactory;
+
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.XMLReaderFactory;
+
+final class JDKSpecific {
+
+    static final ClassLoader SAFE_CL;
+
+    static {
+        // Unfortunately we can not use a null TCCL because of a stupid bug in the jdk JAXP factory finder.
+        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
+        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
+        // Thus, the class can not be found.
+        //
+        // Work around the problem by finding or creating a safe non-null CL to use for our operations.
+
+        ClassLoader safeClassLoader = JDKSpecific.class.getClassLoader();
+        if (safeClassLoader == null) {
+            safeClassLoader = ClassLoader.getSystemClassLoader();
+        }
+        if (safeClassLoader == null) {
+            safeClassLoader = new ClassLoader() {
+            };
+        }
+        SAFE_CL = safeClassLoader;
+    }
+
+    static Supplier<DatatypeFactory> getPlatformDatatypeFactorySupplier() {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+        thread.setContextClassLoader(SAFE_CL);
+        try {
+            clearProperty(DatatypeFactory.class, __DatatypeFactory.class);
+            final Supplier<DatatypeFactory> supplier = getConstructorSupplier(DatatypeFactory.newInstance());
+            System.setProperty(DatatypeFactory.class.getName(), __DatatypeFactory.class.getName());
+            return supplier;
+        } catch (DatatypeConfigurationException e) {
+            throw new IllegalArgumentException("Problem configuring DatatypeFactory", e);
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    static Supplier<DocumentBuilderFactory> getPlatformDocumentBuilderFactorySupplier() {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+        thread.setContextClassLoader(SAFE_CL);
+        try {
+            clearProperty(DocumentBuilderFactory.class, __DocumentBuilderFactory.class);
+            final Supplier<DocumentBuilderFactory> supplier = getConstructorSupplier(DocumentBuilderFactory.newInstance());
+            System.setProperty(DocumentBuilderFactory.class.getName(), __DocumentBuilderFactory.class.getName());
+            return supplier;
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    static Supplier<SAXParserFactory> getPlatformSaxParserFactorySupplier() {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+        thread.setContextClassLoader(SAFE_CL);
+        try {
+            clearProperty(SAXParserFactory.class, __SAXParserFactory.class);
+            final Supplier<SAXParserFactory> supplier = getConstructorSupplier(SAXParserFactory.newInstance());
+            System.setProperty(SAXParserFactory.class.getName(), __SAXParserFactory.class.getName());
+            return supplier;
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    static Supplier<SchemaFactory> getPlatformSchemaFactorySupplier() {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+        thread.setContextClassLoader(SAFE_CL);
+        try {
+            clearProperty(SchemaFactory.class, __SchemaFactory.class);
+            final Supplier<SchemaFactory> supplier = getConstructorSupplier(SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI));
+            System.setProperty(SchemaFactory.class.getName() + ":" + XMLConstants.W3C_XML_SCHEMA_NS_URI, __SchemaFactory.class.getName());
+            return supplier;
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    static Supplier<TransformerFactory> getPlatformSaxTransformerFactorySupplier() {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+        thread.setContextClassLoader(SAFE_CL);
+        try {
+            clearProperty(TransformerFactory.class, __TransformerFactory.class);
+            final Supplier<TransformerFactory> supplier = getConstructorSupplier(TransformerFactory.newInstance());
+            System.setProperty(TransformerFactory.class.getName(), __TransformerFactory.class.getName());
+            return supplier;
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    static Supplier<XMLEventFactory> getPlatformXmlEventFactorySupplier() {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+        thread.setContextClassLoader(SAFE_CL);
+        try {
+            clearProperty(XMLEventFactory.class, __XMLEventFactory.class);
+            final Supplier<XMLEventFactory> supplier = getConstructorSupplier(XMLEventFactory.newInstance());
+            System.setProperty(XMLEventFactory.class.getName(), __XMLEventFactory.class.getName());
+            return supplier;
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    static Supplier<XMLInputFactory> getPlatformXmlInputFactorySupplier() {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+        thread.setContextClassLoader(SAFE_CL);
+        try {
+            clearProperty(XMLInputFactory.class, __XMLInputFactory.class);
+            final Supplier<XMLInputFactory> supplier = getConstructorSupplier(XMLInputFactory.newInstance());
+            System.setProperty(XMLInputFactory.class.getName(), __XMLInputFactory.class.getName());
+            return supplier;
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    static Supplier<XMLOutputFactory> getPlatformXmlOutputFactorySupplier() {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+        thread.setContextClassLoader(SAFE_CL);
+        try {
+            clearProperty(XMLOutputFactory.class, __XMLOutputFactory .class);
+            final Supplier<XMLOutputFactory> supplier = getConstructorSupplier(XMLOutputFactory.newInstance());
+            System.setProperty(XMLOutputFactory.class.getName(), __XMLOutputFactory.class.getName());
+            return supplier;
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    static Supplier<XMLReader> getPlatformXmlReaderSupplier() {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+        thread.setContextClassLoader(SAFE_CL);
+        // MODULES-248: XMLReaderFactory fields tracking if jar files were already scanned needs to reset
+        // before and after switching class loader
+        resetScanTracking();
+        try {
+            clearProperty(__XMLReaderFactory.SAX_DRIVER, __XMLReaderFactory.class);
+            final Supplier<XMLReader> supplier = getConstructorSupplier(XMLReaderFactory.createXMLReader());
+            System.setProperty(__XMLReaderFactory.SAX_DRIVER, __XMLReaderFactory.class.getName());
+            return supplier;
+        } catch (SAXException e) {
+             throw __RedirectedUtils.wrapped(new RuntimeException(e.getMessage()), e);
+        } finally {
+            resetScanTracking();
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    static Supplier<XPathFactory> getPlatformXPathFactorySupplier() {
+        Thread thread = Thread.currentThread();
+        ClassLoader old = thread.getContextClassLoader();
+        thread.setContextClassLoader(SAFE_CL);
+        try {
+            clearProperty(XPathFactory.class, __XPathFactory.class);
+            final Supplier<XPathFactory> supplier = getConstructorSupplier(XPathFactory.newInstance());
+            System.setProperty(XPathFactory.class.getName() + ":" + XPathFactory.DEFAULT_OBJECT_MODEL_URI, __XPathFactory.class.getName());
+            return supplier;
+        } finally {
+            thread.setContextClassLoader(old);
+        }
+    }
+
+    private static void resetScanTracking() {
+        try {
+            Field clsFromJar = XMLReaderFactory.class.getDeclaredField("_clsFromJar");
+            clsFromJar.setAccessible(true);
+            clsFromJar.set(XMLReaderFactory.class, null);
+            Field jarread = XMLReaderFactory.class.getDeclaredField("_jarread");
+            jarread.setAccessible(true);
+            jarread.setBoolean(XMLReaderFactory.class, false);
+        } catch (NoSuchFieldException e) {
+            //no-op, original SAX XMLReaderFactory hasn't helper fields _clsFromJar and _jarread
+        } catch (IllegalAccessException e) {
+            throw __RedirectedUtils.wrapped(new RuntimeException(e.getMessage()), e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Supplier<T> getConstructorSupplier(final T factory) {
+        try {
+            return new ConstructorSupplier<T>((Constructor<? extends T>) factory.getClass().getConstructor());
+        } catch (NoSuchMethodException e) {
+            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        }
+    }
+
+    private static void clearProperty(final Class<?> propertyClass, final Class<?> expectClass) {
+        clearProperty(propertyClass.getName(), expectClass);
+    }
+
+    private static void clearProperty(final String propertyName, final Class<?> expectClass) {
+        if (System.getProperty(propertyName, "").equals(expectClass.getName())) {
+            System.clearProperty(propertyName);
+        }
+    }
+}

--- a/src/main/java/__redirected/__DatatypeFactory.java
+++ b/src/main/java/__redirected/__DatatypeFactory.java
@@ -38,7 +38,7 @@ import org.jboss.modules.ModuleLoader;
 @SuppressWarnings("unchecked")
 public final class __DatatypeFactory extends DatatypeFactory {
     private static final Supplier<DatatypeFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformDatatypeFactorySupplier();
-    private static volatile Supplier<DatatypeFactory> DEFAULT_FACTORY;
+    private static volatile Supplier<DatatypeFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {

--- a/src/main/java/__redirected/__DatatypeFactory.java
+++ b/src/main/java/__redirected/__DatatypeFactory.java
@@ -40,6 +40,10 @@ public final class __DatatypeFactory extends DatatypeFactory {
     private static final Supplier<DatatypeFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformDatatypeFactorySupplier();
     private static volatile Supplier<DatatypeFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
+    static {
+        System.setProperty(DatatypeFactory.class.getName(), __DatatypeFactory.class.getName());
+    }
+
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);

--- a/src/main/java/__redirected/__DatatypeFactory.java
+++ b/src/main/java/__redirected/__DatatypeFactory.java
@@ -40,10 +40,6 @@ public final class __DatatypeFactory extends DatatypeFactory {
     private static final Supplier<DatatypeFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformDatatypeFactorySupplier();
     private static volatile Supplier<DatatypeFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
-    static {
-        System.setProperty(DatatypeFactory.class.getName(), __DatatypeFactory.class.getName());
-    }
-
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);
@@ -63,20 +59,14 @@ public final class __DatatypeFactory extends DatatypeFactory {
     /**
      * Init method.
      */
+    @Deprecated
     public static void init() {}
 
     /**
      * Construct a new instance.
      */
     public __DatatypeFactory() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        Supplier<DatatypeFactory> factory = null;
-        if (loader != null) {
-            factory = __RedirectedUtils.loadProvider(DatatypeFactory.class, loader);
-        }
-        if (factory == null) factory = DEFAULT_FACTORY;
-
-        actual = factory.get();
+        actual = DEFAULT_FACTORY.get();
     }
 
     private final DatatypeFactory actual;

--- a/src/main/java/__redirected/__DatatypeFactory.java
+++ b/src/main/java/__redirected/__DatatypeFactory.java
@@ -18,13 +18,11 @@
 
 package __redirected;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.GregorianCalendar;
+import java.util.function.Supplier;
 
-import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -39,38 +37,8 @@ import org.jboss.modules.ModuleLoader;
  */
 @SuppressWarnings("unchecked")
 public final class __DatatypeFactory extends DatatypeFactory {
-    private static final Constructor<? extends DatatypeFactory> PLATFORM_FACTORY;
-    private static volatile Constructor<? extends DatatypeFactory> DEFAULT_FACTORY;
-
-    static {
-        Thread thread = Thread.currentThread();
-        ClassLoader old = thread.getContextClassLoader();
-
-        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
-        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
-        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
-        // Thus, the class can not be found.
-        //
-        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
-        // the environment's TCCL
-        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
-        try {
-            if (System.getProperty(DatatypeFactory.class.getName(), "").equals(__DatatypeFactory.class.getName())) {
-                System.clearProperty(DatatypeFactory.class.getName());
-            }
-            DatatypeFactory factory = DatatypeFactory.newInstance();
-            try {
-                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
-            System.setProperty(DatatypeFactory.class.getName(), __DatatypeFactory.class.getName());
-        } catch (DatatypeConfigurationException e) {
-            throw new IllegalArgumentException("Problem configuring DatatypeFactory", e);
-        } finally {
-            thread.setContextClassLoader(old);
-        }
-    }
+    private static final Supplier<DatatypeFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformDatatypeFactorySupplier();
+    private static volatile Supplier<DatatypeFactory> DEFAULT_FACTORY;
 
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
@@ -78,13 +46,9 @@ public final class __DatatypeFactory extends DatatypeFactory {
     }
 
     public static void changeDefaultFactory(String id, ModuleLoader loader) {
-        Class<? extends DatatypeFactory> clazz = __RedirectedUtils.loadProvider(id, DatatypeFactory.class, loader);
-        if (clazz != null) {
-            try {
-                DEFAULT_FACTORY = clazz.getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
+        final Supplier<DatatypeFactory> supplier = __RedirectedUtils.loadProvider(id, DatatypeFactory.class, loader);
+        if (supplier != null) {
+            DEFAULT_FACTORY = supplier;
         }
     }
 
@@ -101,25 +65,14 @@ public final class __DatatypeFactory extends DatatypeFactory {
      * Construct a new instance.
      */
     public __DatatypeFactory() {
-        Constructor<? extends DatatypeFactory> factory = DEFAULT_FACTORY;
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        try {
-            if (loader != null) {
-                Class<? extends DatatypeFactory> provider = __RedirectedUtils.loadProvider(DatatypeFactory.class, loader);
-                if (provider != null)
-                    factory = provider.getConstructor();
-            }
-
-            actual = factory.newInstance();
-        } catch (InstantiationException e) {
-            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
-        } catch (IllegalAccessException e) {
-            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
-        } catch (InvocationTargetException e) {
-            throw __RedirectedUtils.rethrowCause(e);
-        } catch (NoSuchMethodException e) {
-            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        Supplier<DatatypeFactory> factory = null;
+        if (loader != null) {
+            factory = __RedirectedUtils.loadProvider(DatatypeFactory.class, loader);
         }
+        if (factory == null) factory = DEFAULT_FACTORY;
+
+        actual = factory.get();
     }
 
     private final DatatypeFactory actual;

--- a/src/main/java/__redirected/__DocumentBuilderFactory.java
+++ b/src/main/java/__redirected/__DocumentBuilderFactory.java
@@ -38,13 +38,10 @@ public final class __DocumentBuilderFactory extends DocumentBuilderFactory {
     private static final Supplier<DocumentBuilderFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformDocumentBuilderFactorySupplier();
     private static volatile Supplier<DocumentBuilderFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
-    static {
-        System.setProperty(DocumentBuilderFactory.class.getName(), __DocumentBuilderFactory.class.getName());
-    }
-
     /**
      * Init method.
      */
+    @Deprecated
     public static void init() {}
 
     @Deprecated
@@ -67,14 +64,7 @@ public final class __DocumentBuilderFactory extends DocumentBuilderFactory {
      * Construct a new instance.
      */
     public __DocumentBuilderFactory() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        Supplier<DocumentBuilderFactory> factory = null;
-        if (loader != null) {
-            factory = __RedirectedUtils.loadProvider(DocumentBuilderFactory.class, loader);
-        }
-        if (factory == null) factory = DEFAULT_FACTORY;
-
-        actual = factory.get();
+        actual = DEFAULT_FACTORY.get();
     }
 
     private final DocumentBuilderFactory actual;

--- a/src/main/java/__redirected/__DocumentBuilderFactory.java
+++ b/src/main/java/__redirected/__DocumentBuilderFactory.java
@@ -18,8 +18,7 @@
 
 package __redirected;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
+import java.util.function.Supplier;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -36,36 +35,8 @@ import org.jboss.modules.ModuleLoader;
  * @author Jason T. Greene
  */
 public final class __DocumentBuilderFactory extends DocumentBuilderFactory {
-    private static final Constructor<? extends DocumentBuilderFactory> PLATFORM_FACTORY;
-    private static volatile Constructor<? extends DocumentBuilderFactory> DEFAULT_FACTORY;
-
-    static {
-        Thread thread = Thread.currentThread();
-        ClassLoader old = thread.getContextClassLoader();
-
-        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
-        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
-        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
-        // Thus, the class can not be found.
-        //
-        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
-        // the environment's TCCL
-        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
-        try {
-            if (System.getProperty(DocumentBuilderFactory.class.getName(), "").equals(__DocumentBuilderFactory.class.getName())) {
-                System.clearProperty(DocumentBuilderFactory.class.getName());
-            }
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            try {
-                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
-            System.setProperty(DocumentBuilderFactory.class.getName(), __DocumentBuilderFactory.class.getName());
-        } finally {
-            thread.setContextClassLoader(old);
-        }
-    }
+    private static final Supplier<DocumentBuilderFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformDocumentBuilderFactorySupplier();
+    private static volatile Supplier<DocumentBuilderFactory> DEFAULT_FACTORY;
 
     /**
      * Init method.
@@ -78,13 +49,9 @@ public final class __DocumentBuilderFactory extends DocumentBuilderFactory {
     }
 
     public static void changeDefaultFactory(String id, ModuleLoader loader) {
-        Class<? extends DocumentBuilderFactory> clazz = __RedirectedUtils.loadProvider(id, DocumentBuilderFactory.class, loader);
-        if (clazz != null) {
-            try {
-                DEFAULT_FACTORY = clazz.getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
+        final Supplier<DocumentBuilderFactory> supplier = __RedirectedUtils.loadProvider(id, DocumentBuilderFactory.class, loader);
+        if (supplier != null) {
+            DEFAULT_FACTORY = supplier;
         }
     }
 
@@ -96,25 +63,14 @@ public final class __DocumentBuilderFactory extends DocumentBuilderFactory {
      * Construct a new instance.
      */
     public __DocumentBuilderFactory() {
-        Constructor<? extends DocumentBuilderFactory> factory = DEFAULT_FACTORY;
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        try {
-            if (loader != null) {
-                Class<? extends DocumentBuilderFactory> provider = __RedirectedUtils.loadProvider(DocumentBuilderFactory.class, loader);
-                if (provider != null)
-                    factory = provider.getConstructor();
-            }
-
-            actual = factory.newInstance();
-        } catch (InstantiationException e) {
-            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
-        } catch (IllegalAccessException e) {
-            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
-        } catch (InvocationTargetException e) {
-            throw __RedirectedUtils.rethrowCause(e);
-        } catch (NoSuchMethodException e) {
-            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        Supplier<DocumentBuilderFactory> factory = null;
+        if (loader != null) {
+            factory = __RedirectedUtils.loadProvider(DocumentBuilderFactory.class, loader);
         }
+        if (factory == null) factory = DEFAULT_FACTORY;
+
+        actual = factory.get();
     }
 
     private final DocumentBuilderFactory actual;

--- a/src/main/java/__redirected/__DocumentBuilderFactory.java
+++ b/src/main/java/__redirected/__DocumentBuilderFactory.java
@@ -36,7 +36,7 @@ import org.jboss.modules.ModuleLoader;
  */
 public final class __DocumentBuilderFactory extends DocumentBuilderFactory {
     private static final Supplier<DocumentBuilderFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformDocumentBuilderFactorySupplier();
-    private static volatile Supplier<DocumentBuilderFactory> DEFAULT_FACTORY;
+    private static volatile Supplier<DocumentBuilderFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
     /**
      * Init method.

--- a/src/main/java/__redirected/__DocumentBuilderFactory.java
+++ b/src/main/java/__redirected/__DocumentBuilderFactory.java
@@ -38,6 +38,10 @@ public final class __DocumentBuilderFactory extends DocumentBuilderFactory {
     private static final Supplier<DocumentBuilderFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformDocumentBuilderFactorySupplier();
     private static volatile Supplier<DocumentBuilderFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
+    static {
+        System.setProperty(DocumentBuilderFactory.class.getName(), __DocumentBuilderFactory.class.getName());
+    }
+
     /**
      * Init method.
      */

--- a/src/main/java/__redirected/__JAXPRedirected.java
+++ b/src/main/java/__redirected/__JAXPRedirected.java
@@ -78,20 +78,4 @@ public class __JAXPRedirected {
         __SchemaFactory.restorePlatformFactory();
         __XMLReaderFactory.restorePlatformFactory();
     }
-
-    /**
-     * Initializes the JAXP redirection system.
-     */
-    public static void initAll() {
-        __DocumentBuilderFactory.init();
-        __SAXParserFactory.init();
-        __TransformerFactory.init();
-        __XPathFactory.init();
-        __XMLEventFactory.init();
-        __XMLInputFactory.init();
-        __XMLOutputFactory.init();
-        __DatatypeFactory.init();
-        __SchemaFactory.init();
-        __XMLReaderFactory.init();
-    }
 }

--- a/src/main/java/__redirected/__RedirectedUtils.java
+++ b/src/main/java/__redirected/__RedirectedUtils.java
@@ -163,6 +163,8 @@ public final class __RedirectedUtils {
                 line = line.trim();
                 if (line.length() == 0)
                     continue;
+                if (line.startsWith("__redirected"))
+                    continue;
 
                 list.add(line);
             }

--- a/src/main/java/__redirected/__RedirectedUtils.java
+++ b/src/main/java/__redirected/__RedirectedUtils.java
@@ -28,6 +28,7 @@ import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleClassLoader;
@@ -77,16 +78,16 @@ public final class __RedirectedUtils {
         return e;
     }
 
-    static <T> Class<? extends T> loadProvider(String id, Class<T> intf, ModuleLoader moduleLoader) {
+    static <T> Supplier<T> loadProvider(String id, Class<T> intf, ModuleLoader moduleLoader) {
         return loadProvider(id, intf, moduleLoader, null);
     }
 
-    static <T> Class<? extends T> loadProvider(String id, Class<T> intf, ModuleLoader moduleLoader, String name) {
+    static <T> Supplier<T> loadProvider(String id, Class<T> intf, ModuleLoader moduleLoader, String name) {
         Module module;
         try {
             module = moduleLoader.loadModule(id);
         } catch (ModuleLoadException e) {
-            getModuleLogger().providerUnloadable(id.toString(), null);
+            getModuleLogger().providerUnloadable(id, null);
             return null;
         }
 
@@ -94,11 +95,11 @@ public final class __RedirectedUtils {
         return loadProvider(intf, classLoader, name);
     }
 
-    static <T> Class<? extends T> loadProvider(Class<T> intf, ClassLoader classLoader) {
+    static <T> Supplier<T> loadProvider(Class<T> intf, ClassLoader classLoader) {
         return loadProvider(intf, classLoader, null);
     }
 
-    static <T> Class<? extends T> loadProvider(Class<T> intf, ClassLoader classLoader, String name) {
+    static <T> Supplier<T> loadProvider(Class<T> intf, ClassLoader classLoader, String name) {
         List<String> names = findProviderClassNames(intf, classLoader, name);
 
         if (names.isEmpty()) {
@@ -108,18 +109,18 @@ public final class __RedirectedUtils {
 
         String clazzName = names.get(0);
         try {
-            return classLoader.loadClass(clazzName).asSubclass(intf);
+            return new ConstructorSupplier<>(classLoader.loadClass(clazzName).asSubclass(intf).getConstructor());
         } catch (Exception ignore) {
             getModuleLogger().providerUnloadable(clazzName, classLoader);
             return null;
         }
     }
 
-    static <T> List<Class<? extends T>> loadProviders(Class<T> intf, ClassLoader classLoader) {
+    static <T> List<Supplier<T>> loadProviders(Class<T> intf, ClassLoader classLoader) {
         return loadProviders(intf, classLoader, null);
     }
 
-    static <T> List<Class<? extends T>> loadProviders(Class<T> intf, ClassLoader classLoader, String name) {
+    static <T> List<Supplier<T>> loadProviders(Class<T> intf, ClassLoader classLoader, String name) {
         List<String> names = findProviderClassNames(intf, classLoader, name);
 
         if (names.size() < 1) {
@@ -127,17 +128,17 @@ public final class __RedirectedUtils {
             return Collections.emptyList();
         }
 
-        List<Class<? extends T>> classes = new ArrayList<Class<? extends T>>();
+        List<Supplier<T>> suppliers = new ArrayList<>();
 
         for (String className : names) {
             try {
-                classes.add(classLoader.loadClass(className).asSubclass(intf));
+                suppliers.add(new ConstructorSupplier<>(classLoader.loadClass(className).asSubclass(intf).getConstructor()));
             } catch (Exception ignore) {
                 getModuleLogger().providerUnloadable(className, classLoader);
             }
         }
 
-        return classes;
+        return suppliers;
     }
 
     static <T> List<String> findProviderClassNames(Class<T> intf, ClassLoader loader, String name) {

--- a/src/main/java/__redirected/__SAXParserFactory.java
+++ b/src/main/java/__redirected/__SAXParserFactory.java
@@ -41,10 +41,6 @@ public final class __SAXParserFactory extends SAXParserFactory {
     private static final Supplier<SAXParserFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformSaxParserFactorySupplier();
     private static volatile Supplier<SAXParserFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
-    static {
-        System.setProperty(SAXParserFactory.class.getName(), __SAXParserFactory.class.getName());
-    }
-
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);
@@ -64,20 +60,14 @@ public final class __SAXParserFactory extends SAXParserFactory {
     /**
      * Init method.
      */
+    @Deprecated
     public static void init() {}
 
     /**
      * Construct a new instance.
      */
     public __SAXParserFactory() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        Supplier<SAXParserFactory> factory = null;
-        if (loader != null) {
-            factory = __RedirectedUtils.loadProvider(SAXParserFactory.class, loader);
-        }
-        if (factory == null) factory = DEFAULT_FACTORY;
-
-        actual = factory.get();
+        actual = DEFAULT_FACTORY.get();
     }
 
     private final SAXParserFactory actual;

--- a/src/main/java/__redirected/__SAXParserFactory.java
+++ b/src/main/java/__redirected/__SAXParserFactory.java
@@ -41,6 +41,10 @@ public final class __SAXParserFactory extends SAXParserFactory {
     private static final Supplier<SAXParserFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformSaxParserFactorySupplier();
     private static volatile Supplier<SAXParserFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
+    static {
+        System.setProperty(SAXParserFactory.class.getName(), __SAXParserFactory.class.getName());
+    }
+
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);

--- a/src/main/java/__redirected/__SAXParserFactory.java
+++ b/src/main/java/__redirected/__SAXParserFactory.java
@@ -39,7 +39,7 @@ import org.xml.sax.SAXNotSupportedException;
  */
 public final class __SAXParserFactory extends SAXParserFactory {
     private static final Supplier<SAXParserFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformSaxParserFactorySupplier();
-    private static volatile Supplier<SAXParserFactory> DEFAULT_FACTORY;
+    private static volatile Supplier<SAXParserFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {

--- a/src/main/java/__redirected/__SAXParserFactory.java
+++ b/src/main/java/__redirected/__SAXParserFactory.java
@@ -18,8 +18,7 @@
 
 package __redirected;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
+import java.util.function.Supplier;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -39,36 +38,8 @@ import org.xml.sax.SAXNotSupportedException;
  * @author Jason T. Greene
  */
 public final class __SAXParserFactory extends SAXParserFactory {
-    private static final Constructor<? extends SAXParserFactory> PLATFORM_FACTORY;
-    private static volatile Constructor<? extends SAXParserFactory> DEFAULT_FACTORY;
-
-    static {
-        Thread thread = Thread.currentThread();
-        ClassLoader old = thread.getContextClassLoader();
-
-        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
-        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
-        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
-        // Thus, the class can not be found.
-        //
-        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
-        // the environment's TCCL
-        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
-        try {
-            if (System.getProperty(SAXParserFactory.class.getName(), "").equals(__SAXParserFactory.class.getName())) {
-                System.clearProperty(SAXParserFactory.class.getName());
-            }
-            SAXParserFactory factory = SAXParserFactory.newInstance();
-            try {
-               DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
-            System.setProperty(SAXParserFactory.class.getName(), __SAXParserFactory.class.getName());
-        } finally {
-            thread.setContextClassLoader(old);
-        }
-    }
+    private static final Supplier<SAXParserFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformSaxParserFactorySupplier();
+    private static volatile Supplier<SAXParserFactory> DEFAULT_FACTORY;
 
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
@@ -76,13 +47,9 @@ public final class __SAXParserFactory extends SAXParserFactory {
     }
 
     public static void changeDefaultFactory(String id, ModuleLoader loader) {
-        Class<? extends SAXParserFactory> clazz = __RedirectedUtils.loadProvider(id, SAXParserFactory.class, loader);
-        if (clazz != null) {
-            try {
-                DEFAULT_FACTORY = clazz.getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
+        final Supplier<SAXParserFactory> supplier = __RedirectedUtils.loadProvider(id, SAXParserFactory.class, loader);
+        if (supplier != null) {
+            DEFAULT_FACTORY = supplier;
         }
     }
 
@@ -99,25 +66,14 @@ public final class __SAXParserFactory extends SAXParserFactory {
      * Construct a new instance.
      */
     public __SAXParserFactory() {
-        Constructor<? extends SAXParserFactory> factory = DEFAULT_FACTORY;
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        try {
-            if (loader != null) {
-                Class<? extends SAXParserFactory> provider = __RedirectedUtils.loadProvider(SAXParserFactory.class, loader);
-                if (provider != null)
-                    factory = provider.getConstructor();
-            }
-
-            actual = factory.newInstance();
-        } catch (InstantiationException e) {
-            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
-        } catch (IllegalAccessException e) {
-            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
-        } catch (InvocationTargetException e) {
-            throw __RedirectedUtils.rethrowCause(e);
-        } catch (NoSuchMethodException e) {
-            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        Supplier<SAXParserFactory> factory = null;
+        if (loader != null) {
+            factory = __RedirectedUtils.loadProvider(SAXParserFactory.class, loader);
         }
+        if (factory == null) factory = DEFAULT_FACTORY;
+
+        actual = factory.get();
     }
 
     private final SAXParserFactory actual;

--- a/src/main/java/__redirected/__SchemaFactory.java
+++ b/src/main/java/__redirected/__SchemaFactory.java
@@ -20,10 +20,8 @@ package __redirected;
 
 import java.io.File;
 import java.net.URL;
-import java.util.List;
 import java.util.function.Supplier;
 
-import javax.xml.XMLConstants;
 import javax.xml.transform.Source;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -45,10 +43,6 @@ public final class __SchemaFactory extends SchemaFactory {
     private static final Supplier<SchemaFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformSchemaFactorySupplier();
     private static volatile Supplier<SchemaFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
-    static {
-        System.setProperty(SchemaFactory.class.getName() + ":" + XMLConstants.W3C_XML_SCHEMA_NS_URI, __SchemaFactory.class.getName());
-    }
-
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);
@@ -68,25 +62,14 @@ public final class __SchemaFactory extends SchemaFactory {
     /**
      * Init method.
      */
+    @Deprecated
     public static void init() {}
 
     /**
      * Construct a new instance.
      */
     public __SchemaFactory() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        SchemaFactory foundInstance = null;
-        if (loader != null) {
-            final List<Supplier<SchemaFactory>> providers = __RedirectedUtils.loadProviders(SchemaFactory.class, loader);
-            for (Supplier<SchemaFactory> provider : providers) {
-                SchemaFactory instance = provider.get();
-                if (instance.isSchemaLanguageSupported(XMLConstants.W3C_XML_SCHEMA_NS_URI)) {
-                    foundInstance = instance;
-                    break;
-                }
-            }
-        }
-        actual = foundInstance != null ? foundInstance : DEFAULT_FACTORY.get();
+        actual = DEFAULT_FACTORY.get();
     }
 
 

--- a/src/main/java/__redirected/__SchemaFactory.java
+++ b/src/main/java/__redirected/__SchemaFactory.java
@@ -19,10 +19,9 @@
 package __redirected;
 
 import java.io.File;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.xml.XMLConstants;
 import javax.xml.transform.Source;
@@ -43,36 +42,8 @@ import org.xml.sax.SAXNotSupportedException;
  * @author Jason T. Greene
  */
 public final class __SchemaFactory extends SchemaFactory {
-    private static final Constructor<? extends SchemaFactory> PLATFORM_FACTORY;
-    private static volatile Constructor<? extends SchemaFactory> DEFAULT_FACTORY;
-
-    static {
-        Thread thread = Thread.currentThread();
-        ClassLoader old = thread.getContextClassLoader();
-
-        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
-        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
-        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
-        // Thus, the class can not be found.
-        //
-        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
-        // the environment's TCCL
-        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
-        try {
-            if (System.getProperty(SchemaFactory.class.getName(), "").equals(__SchemaFactory.class.getName())) {
-                System.clearProperty(SchemaFactory.class.getName());
-            }
-            SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-            try {
-                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
-            System.setProperty(SchemaFactory.class.getName() + ":" + XMLConstants.W3C_XML_SCHEMA_NS_URI, __SchemaFactory.class.getName());
-        } finally {
-            thread.setContextClassLoader(old);
-        }
-    }
+    private static final Supplier<SchemaFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformSchemaFactorySupplier();
+    private static volatile Supplier<SchemaFactory> DEFAULT_FACTORY;
 
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
@@ -80,13 +51,9 @@ public final class __SchemaFactory extends SchemaFactory {
     }
 
     public static void changeDefaultFactory(String id, ModuleLoader loader) {
-        Class<? extends SchemaFactory> clazz = __RedirectedUtils.loadProvider(id, SchemaFactory.class, loader);
-        if (clazz != null) {
-            try {
-                DEFAULT_FACTORY = clazz.getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
+        final Supplier<SchemaFactory> supplier = __RedirectedUtils.loadProvider(id, SchemaFactory.class, loader);
+        if (supplier != null) {
+            DEFAULT_FACTORY = supplier;
         }
     }
 
@@ -103,30 +70,19 @@ public final class __SchemaFactory extends SchemaFactory {
      * Construct a new instance.
      */
     public __SchemaFactory() {
-        Constructor<? extends SchemaFactory> factory = DEFAULT_FACTORY;
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
         SchemaFactory foundInstance = null;
-        try {
-            if (loader != null) {
-                List<Class<? extends SchemaFactory>> providers = __RedirectedUtils.loadProviders(SchemaFactory.class, loader);
-                for (Class<? extends SchemaFactory> provider : providers) {
-                    SchemaFactory instance = provider.newInstance();
-                    if (instance.isSchemaLanguageSupported(XMLConstants.W3C_XML_SCHEMA_NS_URI)) {
-                        foundInstance = instance;
-                        break;
-                    }
+        if (loader != null) {
+            final List<Supplier<SchemaFactory>> providers = __RedirectedUtils.loadProviders(SchemaFactory.class, loader);
+            for (Supplier<SchemaFactory> provider : providers) {
+                SchemaFactory instance = provider.get();
+                if (instance.isSchemaLanguageSupported(XMLConstants.W3C_XML_SCHEMA_NS_URI)) {
+                    foundInstance = instance;
+                    break;
                 }
             }
-
-            actual = foundInstance != null ? foundInstance : factory.newInstance();
-
-        } catch (InstantiationException e) {
-            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
-        } catch (IllegalAccessException e) {
-            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
-        } catch (InvocationTargetException e) {
-            throw __RedirectedUtils.rethrowCause(e);
         }
+        actual = foundInstance != null ? foundInstance : DEFAULT_FACTORY.get();
     }
 
 

--- a/src/main/java/__redirected/__SchemaFactory.java
+++ b/src/main/java/__redirected/__SchemaFactory.java
@@ -45,6 +45,10 @@ public final class __SchemaFactory extends SchemaFactory {
     private static final Supplier<SchemaFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformSchemaFactorySupplier();
     private static volatile Supplier<SchemaFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
+    static {
+        System.setProperty(SchemaFactory.class.getName() + ":" + XMLConstants.W3C_XML_SCHEMA_NS_URI, __SchemaFactory.class.getName());
+    }
+
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);

--- a/src/main/java/__redirected/__SchemaFactory.java
+++ b/src/main/java/__redirected/__SchemaFactory.java
@@ -43,7 +43,7 @@ import org.xml.sax.SAXNotSupportedException;
  */
 public final class __SchemaFactory extends SchemaFactory {
     private static final Supplier<SchemaFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformSchemaFactorySupplier();
-    private static volatile Supplier<SchemaFactory> DEFAULT_FACTORY;
+    private static volatile Supplier<SchemaFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {

--- a/src/main/java/__redirected/__TransformerFactory.java
+++ b/src/main/java/__redirected/__TransformerFactory.java
@@ -45,6 +45,10 @@ public final class __TransformerFactory extends SAXTransformerFactory {
     private static final Supplier<TransformerFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformSaxTransformerFactorySupplier();
     private static volatile Supplier<TransformerFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
+    static {
+        System.setProperty(TransformerFactory.class.getName(), __TransformerFactory.class.getName());
+    }
+
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);

--- a/src/main/java/__redirected/__TransformerFactory.java
+++ b/src/main/java/__redirected/__TransformerFactory.java
@@ -43,7 +43,7 @@ import org.xml.sax.XMLFilter;
  */
 public final class __TransformerFactory extends SAXTransformerFactory {
     private static final Supplier<TransformerFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformSaxTransformerFactorySupplier();
-    private static volatile Supplier<TransformerFactory> DEFAULT_FACTORY;
+    private static volatile Supplier<TransformerFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {

--- a/src/main/java/__redirected/__TransformerFactory.java
+++ b/src/main/java/__redirected/__TransformerFactory.java
@@ -45,10 +45,6 @@ public final class __TransformerFactory extends SAXTransformerFactory {
     private static final Supplier<TransformerFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformSaxTransformerFactorySupplier();
     private static volatile Supplier<TransformerFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
-    static {
-        System.setProperty(TransformerFactory.class.getName(), __TransformerFactory.class.getName());
-    }
-
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);
@@ -68,20 +64,14 @@ public final class __TransformerFactory extends SAXTransformerFactory {
     /**
      * Init method.
      */
+    @Deprecated
     public static void init() {}
 
     /**
      * Construct a new instance.
      */
     public __TransformerFactory() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        Supplier<TransformerFactory> factory = null;
-        if (loader != null) {
-            factory = __RedirectedUtils.loadProvider(TransformerFactory.class, loader);
-        }
-        if (factory == null) factory = DEFAULT_FACTORY;
-
-        actual = factory.get();
+        actual = DEFAULT_FACTORY.get();
         saxtual = (actual instanceof SAXTransformerFactory) ? (SAXTransformerFactory)actual : null;
     }
 

--- a/src/main/java/__redirected/__XMLEventFactory.java
+++ b/src/main/java/__redirected/__XMLEventFactory.java
@@ -52,10 +52,6 @@ public final class __XMLEventFactory extends XMLEventFactory {
     private static final Supplier<XMLEventFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXmlEventFactorySupplier();
     private static volatile Supplier<XMLEventFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
-    static {
-        System.setProperty(XMLEventFactory.class.getName(), __XMLEventFactory.class.getName());
-    }
-
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);
@@ -75,20 +71,14 @@ public final class __XMLEventFactory extends XMLEventFactory {
     /**
      * Init method.
      */
+    @Deprecated
     public static void init() {}
 
     /**
      * Construct a new instance.
      */
     public __XMLEventFactory() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        Supplier<XMLEventFactory> factory = null;
-        if (loader != null) {
-            factory = __RedirectedUtils.loadProvider(XMLEventFactory.class, loader);
-        }
-        if (factory == null) factory = DEFAULT_FACTORY;
-
-        actual = factory.get();
+        actual = DEFAULT_FACTORY.get();
     }
 
     private final XMLEventFactory actual;

--- a/src/main/java/__redirected/__XMLEventFactory.java
+++ b/src/main/java/__redirected/__XMLEventFactory.java
@@ -52,6 +52,10 @@ public final class __XMLEventFactory extends XMLEventFactory {
     private static final Supplier<XMLEventFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXmlEventFactorySupplier();
     private static volatile Supplier<XMLEventFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
+    static {
+        System.setProperty(XMLEventFactory.class.getName(), __XMLEventFactory.class.getName());
+    }
+
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);

--- a/src/main/java/__redirected/__XMLEventFactory.java
+++ b/src/main/java/__redirected/__XMLEventFactory.java
@@ -18,9 +18,8 @@
 
 package __redirected;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Iterator;
+import java.util.function.Supplier;
 
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.namespace.QName;
@@ -50,36 +49,8 @@ import org.jboss.modules.ModuleLoader;
  */
 @SuppressWarnings("unchecked")
 public final class __XMLEventFactory extends XMLEventFactory {
-    private static final Constructor<? extends XMLEventFactory> PLATFORM_FACTORY;
-    private static volatile Constructor<? extends XMLEventFactory> DEFAULT_FACTORY;
-
-    static {
-        Thread thread = Thread.currentThread();
-        ClassLoader old = thread.getContextClassLoader();
-
-        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
-        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
-        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
-        // Thus, the class can not be found.
-        //
-        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
-        // the environment's TCCL
-        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
-        try {
-            if (System.getProperty(XMLEventFactory.class.getName(), "").equals(__XMLEventFactory.class.getName())) {
-                System.clearProperty(XMLEventFactory.class.getName());
-            }
-            XMLEventFactory factory = XMLEventFactory.newInstance();
-            try {
-                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
-            System.setProperty(XMLEventFactory.class.getName(), __XMLEventFactory.class.getName());
-        } finally {
-            thread.setContextClassLoader(old);
-        }
-    }
+    private static final Supplier<XMLEventFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXmlEventFactorySupplier();
+    private static volatile Supplier<XMLEventFactory> DEFAULT_FACTORY;
 
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
@@ -87,13 +58,9 @@ public final class __XMLEventFactory extends XMLEventFactory {
     }
 
     public static void changeDefaultFactory(String id, ModuleLoader loader) {
-        Class<? extends XMLEventFactory> clazz = __RedirectedUtils.loadProvider(id, XMLEventFactory.class, loader);
-        if (clazz != null) {
-            try {
-                DEFAULT_FACTORY = clazz.getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
+        final Supplier<XMLEventFactory> supplier = __RedirectedUtils.loadProvider(id, XMLEventFactory.class, loader);
+        if (supplier != null) {
+            DEFAULT_FACTORY = supplier;
         }
     }
 
@@ -110,25 +77,14 @@ public final class __XMLEventFactory extends XMLEventFactory {
      * Construct a new instance.
      */
     public __XMLEventFactory() {
-        Constructor<? extends XMLEventFactory> factory = DEFAULT_FACTORY;
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        try {
-            if (loader != null) {
-                Class<? extends XMLEventFactory> provider = __RedirectedUtils.loadProvider(XMLEventFactory.class, loader);
-                if (provider != null)
-                    factory = provider.getConstructor();
-            }
-
-            actual = factory.newInstance();
-        } catch (InstantiationException e) {
-            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
-        } catch (IllegalAccessException e) {
-            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
-        } catch (InvocationTargetException e) {
-            throw __RedirectedUtils.rethrowCause(e);
-        } catch (NoSuchMethodException e) {
-            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        Supplier<XMLEventFactory> factory = null;
+        if (loader != null) {
+            factory = __RedirectedUtils.loadProvider(XMLEventFactory.class, loader);
         }
+        if (factory == null) factory = DEFAULT_FACTORY;
+
+        actual = factory.get();
     }
 
     private final XMLEventFactory actual;

--- a/src/main/java/__redirected/__XMLEventFactory.java
+++ b/src/main/java/__redirected/__XMLEventFactory.java
@@ -50,7 +50,7 @@ import org.jboss.modules.ModuleLoader;
 @SuppressWarnings("unchecked")
 public final class __XMLEventFactory extends XMLEventFactory {
     private static final Supplier<XMLEventFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXmlEventFactorySupplier();
-    private static volatile Supplier<XMLEventFactory> DEFAULT_FACTORY;
+    private static volatile Supplier<XMLEventFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {

--- a/src/main/java/__redirected/__XMLInputFactory.java
+++ b/src/main/java/__redirected/__XMLInputFactory.java
@@ -44,7 +44,7 @@ import org.jboss.modules.ModuleLoader;
  */
 public final class __XMLInputFactory extends XMLInputFactory {
     private static final Supplier<XMLInputFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXmlInputFactorySupplier();
-    private static volatile Supplier<XMLInputFactory> DEFAULT_FACTORY;
+    private static volatile Supplier<XMLInputFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {

--- a/src/main/java/__redirected/__XMLInputFactory.java
+++ b/src/main/java/__redirected/__XMLInputFactory.java
@@ -46,10 +46,6 @@ public final class __XMLInputFactory extends XMLInputFactory {
     private static final Supplier<XMLInputFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXmlInputFactorySupplier();
     private static volatile Supplier<XMLInputFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
-    static {
-        System.setProperty(XMLInputFactory.class.getName(), __XMLInputFactory.class.getName());
-    }
-
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);
@@ -65,6 +61,7 @@ public final class __XMLInputFactory extends XMLInputFactory {
     /**
      * Init method.
      */
+    @Deprecated
     public static void init() {}
 
     public static void restorePlatformFactory() {
@@ -75,14 +72,7 @@ public final class __XMLInputFactory extends XMLInputFactory {
      * Construct a new instance.
      */
     public __XMLInputFactory() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        Supplier<XMLInputFactory> factory = null;
-        if (loader != null) {
-            factory = __RedirectedUtils.loadProvider(XMLInputFactory.class, loader);
-        }
-        if (factory == null) factory = DEFAULT_FACTORY;
-
-        actual = factory.get();
+        actual = DEFAULT_FACTORY.get();
     }
 
     private final XMLInputFactory actual;

--- a/src/main/java/__redirected/__XMLInputFactory.java
+++ b/src/main/java/__redirected/__XMLInputFactory.java
@@ -46,6 +46,10 @@ public final class __XMLInputFactory extends XMLInputFactory {
     private static final Supplier<XMLInputFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXmlInputFactorySupplier();
     private static volatile Supplier<XMLInputFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
+    static {
+        System.setProperty(XMLInputFactory.class.getName(), __XMLInputFactory.class.getName());
+    }
+
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);

--- a/src/main/java/__redirected/__XMLInputFactory.java
+++ b/src/main/java/__redirected/__XMLInputFactory.java
@@ -20,8 +20,7 @@ package __redirected;
 
 import java.io.InputStream;
 import java.io.Reader;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
+import java.util.function.Supplier;
 
 import javax.xml.stream.EventFilter;
 import javax.xml.stream.StreamFilter;
@@ -44,36 +43,8 @@ import org.jboss.modules.ModuleLoader;
  * @author Jason T. Greene
  */
 public final class __XMLInputFactory extends XMLInputFactory {
-    private static final Constructor<? extends XMLInputFactory> PLATFORM_FACTORY;
-    private static volatile Constructor<? extends XMLInputFactory> DEFAULT_FACTORY;
-
-    static {
-        Thread thread = Thread.currentThread();
-        ClassLoader old = thread.getContextClassLoader();
-
-        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
-        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
-        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
-        // Thus, the class can not be found.
-        //
-        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
-        // the environment's TCCL
-        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
-        try {
-            if (System.getProperty(XMLInputFactory.class.getName(), "").equals(__XMLInputFactory .class.getName())) {
-                System.clearProperty(XMLInputFactory.class.getName());
-            }
-            XMLInputFactory factory = XMLInputFactory.newInstance();
-            try {
-                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
-            System.setProperty(XMLInputFactory.class.getName(), __XMLInputFactory.class.getName());
-        } finally {
-            thread.setContextClassLoader(old);
-        }
-    }
+    private static final Supplier<XMLInputFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXmlInputFactorySupplier();
+    private static volatile Supplier<XMLInputFactory> DEFAULT_FACTORY;
 
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
@@ -81,13 +52,9 @@ public final class __XMLInputFactory extends XMLInputFactory {
     }
 
     public static void changeDefaultFactory(String id, ModuleLoader loader) {
-        Class<? extends XMLInputFactory> clazz = __RedirectedUtils.loadProvider(id, XMLInputFactory.class, loader);
-        if (clazz != null) {
-            try {
-                DEFAULT_FACTORY = clazz.getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
+        final Supplier<XMLInputFactory> supplier = __RedirectedUtils.loadProvider(id, XMLInputFactory.class, loader);
+        if (supplier != null) {
+            DEFAULT_FACTORY = supplier;
         }
     }
 
@@ -104,25 +71,14 @@ public final class __XMLInputFactory extends XMLInputFactory {
      * Construct a new instance.
      */
     public __XMLInputFactory() {
-        Constructor<? extends XMLInputFactory> factory = DEFAULT_FACTORY;
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        try {
-            if (loader != null) {
-                Class<? extends XMLInputFactory> provider = __RedirectedUtils.loadProvider(XMLInputFactory.class, loader);
-                if (provider != null)
-                    factory = provider.getConstructor();
-            }
-
-            actual = factory.newInstance();
-        } catch (InstantiationException e) {
-            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
-        } catch (IllegalAccessException e) {
-            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
-        } catch (InvocationTargetException e) {
-            throw __RedirectedUtils.rethrowCause(e);
-        } catch (NoSuchMethodException e) {
-            throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
+        Supplier<XMLInputFactory> factory = null;
+        if (loader != null) {
+            factory = __RedirectedUtils.loadProvider(XMLInputFactory.class, loader);
         }
+        if (factory == null) factory = DEFAULT_FACTORY;
+
+        actual = factory.get();
     }
 
     private final XMLInputFactory actual;

--- a/src/main/java/__redirected/__XMLOutputFactory.java
+++ b/src/main/java/__redirected/__XMLOutputFactory.java
@@ -41,6 +41,10 @@ public final class __XMLOutputFactory extends XMLOutputFactory {
     private static final Supplier<XMLOutputFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXmlOutputFactorySupplier();
     private static volatile Supplier<XMLOutputFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
+    static {
+        System.setProperty(XMLOutputFactory.class.getName(), __XMLOutputFactory.class.getName());
+    }
+
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);

--- a/src/main/java/__redirected/__XMLOutputFactory.java
+++ b/src/main/java/__redirected/__XMLOutputFactory.java
@@ -39,7 +39,7 @@ import org.jboss.modules.ModuleLoader;
  */
 public final class __XMLOutputFactory extends XMLOutputFactory {
     private static final Supplier<XMLOutputFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXmlOutputFactorySupplier();
-    private static volatile Supplier<XMLOutputFactory> DEFAULT_FACTORY;
+    private static volatile Supplier<XMLOutputFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {

--- a/src/main/java/__redirected/__XMLOutputFactory.java
+++ b/src/main/java/__redirected/__XMLOutputFactory.java
@@ -41,10 +41,6 @@ public final class __XMLOutputFactory extends XMLOutputFactory {
     private static final Supplier<XMLOutputFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXmlOutputFactorySupplier();
     private static volatile Supplier<XMLOutputFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
-    static {
-        System.setProperty(XMLOutputFactory.class.getName(), __XMLOutputFactory.class.getName());
-    }
-
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);
@@ -64,20 +60,14 @@ public final class __XMLOutputFactory extends XMLOutputFactory {
     /**
      * Init method.
      */
+    @Deprecated
     public static void init() {}
 
     /**
      * Construct a new instance.
      */
     public __XMLOutputFactory() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        Supplier<XMLOutputFactory> factory = null;
-        if (loader != null) {
-            factory = __RedirectedUtils.loadProvider(XMLOutputFactory.class, loader);
-        }
-        if (factory == null) factory = DEFAULT_FACTORY;
-
-        actual = factory.get();
+        actual = DEFAULT_FACTORY.get();
     }
 
     private final XMLOutputFactory actual;

--- a/src/main/java/__redirected/__XMLReaderFactory.java
+++ b/src/main/java/__redirected/__XMLReaderFactory.java
@@ -43,11 +43,7 @@ public final class __XMLReaderFactory implements XMLReader {
     private static final Supplier<XMLReader> PLATFORM_FACTORY = JDKSpecific.getPlatformXmlReaderSupplier();
     private static volatile Supplier<XMLReader> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
-    static final String SAX_DRIVER = "org.xml.sax.driver";
-
-    static {
-        System.setProperty(SAX_DRIVER, __XMLReaderFactory.class.getName());
-    }
+    public static final String SAX_DRIVER = "org.xml.sax.driver";
 
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
@@ -68,12 +64,18 @@ public final class __XMLReaderFactory implements XMLReader {
     /**
      * Init method.
      */
+    @Deprecated
     public static void init() {}
 
     /**
      * Construct a new instance.
      */
     public __XMLReaderFactory() {
+        /*
+           This one works a little differently; since XMLReaderFactory (in Java 8) is essentially broken,
+           we forcibly install this class as the global default provider and do the "real" lookup ourselves.
+           Once we require Java 9 (or higher), this should be changed to work like the other factories again.
+         */
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
         Supplier<XMLReader> factory = null;
         if (loader != null) {

--- a/src/main/java/__redirected/__XMLReaderFactory.java
+++ b/src/main/java/__redirected/__XMLReaderFactory.java
@@ -41,7 +41,7 @@ import org.xml.sax.XMLReader;
  */
 public final class __XMLReaderFactory implements XMLReader {
     private static final Supplier<XMLReader> PLATFORM_FACTORY = JDKSpecific.getPlatformXmlReaderSupplier();
-    private static volatile Supplier<XMLReader> DEFAULT_FACTORY;
+    private static volatile Supplier<XMLReader> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
     static final String SAX_DRIVER = "org.xml.sax.driver";
 

--- a/src/main/java/__redirected/__XMLReaderFactory.java
+++ b/src/main/java/__redirected/__XMLReaderFactory.java
@@ -45,6 +45,10 @@ public final class __XMLReaderFactory implements XMLReader {
 
     static final String SAX_DRIVER = "org.xml.sax.driver";
 
+    static {
+        System.setProperty(SAX_DRIVER, __XMLReaderFactory.class.getName());
+    }
+
     @Deprecated
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);

--- a/src/main/java/__redirected/__XPathFactory.java
+++ b/src/main/java/__redirected/__XPathFactory.java
@@ -38,6 +38,10 @@ public final class __XPathFactory extends XPathFactory {
     private static final Supplier<XPathFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXPathFactorySupplier();
     private static volatile Supplier<XPathFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
+    static {
+        System.setProperty(XPathFactory.class.getName() + ":" + XPathFactory.DEFAULT_OBJECT_MODEL_URI, __XPathFactory.class.getName());
+    }
+
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);
     }

--- a/src/main/java/__redirected/__XPathFactory.java
+++ b/src/main/java/__redirected/__XPathFactory.java
@@ -26,7 +26,6 @@ import javax.xml.xpath.XPathFactory;
 import javax.xml.xpath.XPathFactoryConfigurationException;
 import javax.xml.xpath.XPathFunctionResolver;
 import javax.xml.xpath.XPathVariableResolver;
-import java.util.List;
 import java.util.function.Supplier;
 
 /**
@@ -37,10 +36,6 @@ import java.util.function.Supplier;
 public final class __XPathFactory extends XPathFactory {
     private static final Supplier<XPathFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXPathFactorySupplier();
     private static volatile Supplier<XPathFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
-
-    static {
-        System.setProperty(XPathFactory.class.getName() + ":" + XPathFactory.DEFAULT_OBJECT_MODEL_URI, __XPathFactory.class.getName());
-    }
 
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);
@@ -60,25 +55,14 @@ public final class __XPathFactory extends XPathFactory {
     /**
      * Init method.
      */
+    @Deprecated
     public static void init() {}
 
     /**
      * Construct a new instance.
      */
     public __XPathFactory() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        XPathFactory foundInstance = null;
-        if (loader != null) {
-            final List<Supplier<XPathFactory>> providers = __RedirectedUtils.loadProviders(XPathFactory.class, loader);
-            for (Supplier<XPathFactory> provider : providers) {
-                XPathFactory instance = provider.get();
-                if (instance.isObjectModelSupported(XPathFactory.DEFAULT_OBJECT_MODEL_URI)) {
-                    foundInstance = instance;
-                    break;
-                }
-            }
-        }
-        actual = foundInstance != null ? foundInstance : DEFAULT_FACTORY.get();
+        actual = DEFAULT_FACTORY.get();
     }
 
     private final XPathFactory actual;

--- a/src/main/java/__redirected/__XPathFactory.java
+++ b/src/main/java/__redirected/__XPathFactory.java
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
  */
 public final class __XPathFactory extends XPathFactory {
     private static final Supplier<XPathFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXPathFactorySupplier();
-    private static volatile Supplier<XPathFactory> DEFAULT_FACTORY;
+    private static volatile Supplier<XPathFactory> DEFAULT_FACTORY = PLATFORM_FACTORY;
 
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);

--- a/src/main/java/__redirected/__XPathFactory.java
+++ b/src/main/java/__redirected/__XPathFactory.java
@@ -26,9 +26,8 @@ import javax.xml.xpath.XPathFactory;
 import javax.xml.xpath.XPathFactoryConfigurationException;
 import javax.xml.xpath.XPathFunctionResolver;
 import javax.xml.xpath.XPathVariableResolver;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * A redirected XPathFactory
@@ -36,49 +35,17 @@ import java.util.List;
  * @author Jason T. Greene
  */
 public final class __XPathFactory extends XPathFactory {
-    private static final Constructor<? extends XPathFactory> PLATFORM_FACTORY;
-    private static volatile Constructor<? extends XPathFactory> DEFAULT_FACTORY;
-
-    static {
-        Thread thread = Thread.currentThread();
-        ClassLoader old = thread.getContextClassLoader();
-
-        // Unfortunately we can not use null because of a stupid bug in the jdk JAXP factory finder.
-        // Lack of tccl causes the provider file discovery to fallback to the jaxp loader (bootclasspath)
-        // which is correct. However, after parsing it, it then disables the fallback for the loading of the class.
-        // Thus, the class can not be found.
-        //
-        // Work around the problem by using the System CL, although in the future we may want to just "inherit"
-        // the environment's TCCL
-        thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
-        try {
-            if (System.getProperty(XPathFactory.class.getName(), "").equals(__XPathFactory.class.getName())) {
-                System.clearProperty(XPathFactory.class.getName());
-            }
-            XPathFactory factory = XPathFactory.newInstance();
-            try {
-                DEFAULT_FACTORY = PLATFORM_FACTORY = factory.getClass().getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
-            System.setProperty(XPathFactory.class.getName() + ":" + XPathFactory.DEFAULT_OBJECT_MODEL_URI, __XPathFactory.class.getName());
-        } finally {
-            thread.setContextClassLoader(old);
-        }
-    }
+    private static final Supplier<XPathFactory> PLATFORM_FACTORY = JDKSpecific.getPlatformXPathFactorySupplier();
+    private static volatile Supplier<XPathFactory> DEFAULT_FACTORY;
 
     public static void changeDefaultFactory(ModuleIdentifier id, ModuleLoader loader) {
         changeDefaultFactory(id.toString(), loader);
     }
 
     public static void changeDefaultFactory(String id, ModuleLoader loader) {
-        Class<? extends XPathFactory> clazz = __RedirectedUtils.loadProvider(id, XPathFactory.class, loader);
-        if (clazz != null) {
-            try {
-                DEFAULT_FACTORY = clazz.getConstructor();
-            } catch (NoSuchMethodException e) {
-                throw __RedirectedUtils.wrapped(new NoSuchMethodError(e.getMessage()), e);
-            }
+        final Supplier<XPathFactory> supplier = __RedirectedUtils.loadProvider(id, XPathFactory.class, loader);
+        if (supplier != null) {
+            DEFAULT_FACTORY = supplier;
         }
     }
 
@@ -95,30 +62,19 @@ public final class __XPathFactory extends XPathFactory {
      * Construct a new instance.
      */
     public __XPathFactory() {
-        Constructor<? extends XPathFactory> factory = DEFAULT_FACTORY;
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
         XPathFactory foundInstance = null;
-        try {
-            if (loader != null) {
-                List<Class<? extends XPathFactory>> providers = __RedirectedUtils.loadProviders(XPathFactory.class, loader);
-                for (Class<? extends XPathFactory> provider : providers) {
-                    XPathFactory instance = provider.newInstance();
-                    if (instance.isObjectModelSupported(XPathFactory.DEFAULT_OBJECT_MODEL_URI)) {
-                        foundInstance = instance;
-                        break;
-                    }
+        if (loader != null) {
+            final List<Supplier<XPathFactory>> providers = __RedirectedUtils.loadProviders(XPathFactory.class, loader);
+            for (Supplier<XPathFactory> provider : providers) {
+                XPathFactory instance = provider.get();
+                if (instance.isObjectModelSupported(XPathFactory.DEFAULT_OBJECT_MODEL_URI)) {
+                    foundInstance = instance;
+                    break;
                 }
             }
-
-            actual = foundInstance != null ? foundInstance : factory.newInstance();
-
-        } catch (InstantiationException e) {
-            throw __RedirectedUtils.wrapped(new InstantiationError(e.getMessage()), e);
-        } catch (IllegalAccessException e) {
-            throw __RedirectedUtils.wrapped(new IllegalAccessError(e.getMessage()), e);
-        } catch (InvocationTargetException e) {
-            throw __RedirectedUtils.rethrowCause(e);
         }
+        actual = foundInstance != null ? foundInstance : DEFAULT_FACTORY.get();
     }
 
     private final XPathFactory actual;

--- a/src/main/java/org/jboss/modules/DataURLStreamHandler.java
+++ b/src/main/java/org/jboss/modules/DataURLStreamHandler.java
@@ -1,0 +1,256 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.modules;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLDecoder;
+import java.net.URLStreamHandler;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.Base64;
+
+/**
+ */
+final class DataURLStreamHandler extends URLStreamHandler {
+
+    private static final DataURLStreamHandler INSTANCE = new DataURLStreamHandler();
+
+    static DataURLStreamHandler getInstance() {
+        return INSTANCE;
+    }
+
+    private DataURLStreamHandler() {
+    }
+
+    protected URLConnection openConnection(final URL url) throws IOException {
+        return new DataURLConnection(url);
+    }
+
+    static final class DataURLConnection extends URLConnection {
+        private static final int ST_INITIAL = 0;
+        private static final int ST_TYPE = 1;
+        private static final int ST_SUBTYPE = 2;
+        private static final int ST_PARAMETER = 3;
+        private static final int ST_PARAMETER_VAL = 4;
+
+        private final byte[] content;
+        private final String contentString;
+        private final String contentType;
+
+        DataURLConnection(final URL url) throws IOException {
+            super(url);
+
+            // We have to use toString() because otherwise URL will eat '?' characters in the content!
+            String urlString = url.toString();
+            if (! urlString.startsWith("data:")) {
+                // should not happen
+                throw new ProtocolException("Wrong URL scheme");
+            }
+
+            String contentType = "text/plain";
+            StringBuilder contentTypeBuilder = null;
+            int state = ST_INITIAL;
+            final int len = urlString.length();
+            int cp;
+            int postCt = -1;
+            int content = -1;
+            int paramStart = -1;
+            int paramEnd = -1;
+            boolean base64 = false;
+            String charsetName = null;
+            boolean text = true;
+            Charset charset = StandardCharsets.US_ASCII;
+            for (int i = 5; i < len; i = urlString.offsetByCodePoints(i, 1)) {
+                cp = urlString.codePointAt(i);
+                if (state == ST_INITIAL) {
+                    if (isCTToken(cp)) {
+                        state = ST_TYPE;
+                        contentTypeBuilder = new StringBuilder();
+                        contentTypeBuilder.appendCodePoint(Character.toLowerCase(cp));
+                    } else if (cp == ';') {
+                        // default content-type
+                        contentTypeBuilder = new StringBuilder();
+                        contentTypeBuilder.append("text/plain");
+                        postCt = contentTypeBuilder.length();
+                        paramStart = urlString.offsetByCodePoints(i, 1);
+                        state = ST_PARAMETER;
+                    } else if (cp == ',') {
+                        content = urlString.offsetByCodePoints(i, 1);
+                        // done
+                        break;
+                    } else {
+                        throw invalidChar(i);
+                    }
+                } else if (state == ST_TYPE) {
+                    if (isCTToken(cp)) {
+                        contentTypeBuilder.appendCodePoint(Character.toLowerCase(cp));
+                    } else if (cp == '/') {
+                        state = ST_SUBTYPE;
+                        contentTypeBuilder.append('/');
+                    } else {
+                        throw invalidChar(i);
+                    }
+                } else if (state == ST_SUBTYPE) {
+                    if (isCTToken(cp)) {
+                        contentTypeBuilder.appendCodePoint(Character.toLowerCase(cp));
+                    } else if (cp == ';') {
+                        postCt = contentTypeBuilder.length();
+                        paramStart = urlString.offsetByCodePoints(i, 1);
+                        state = ST_PARAMETER;
+                    } else if (cp == ',') {
+                        contentType = contentTypeBuilder.toString();
+                        text = contentType.startsWith("text/");
+                        content = urlString.offsetByCodePoints(i, 1);
+                        // done
+                        break;
+                    } else {
+                        throw invalidChar(i);
+                    }
+                } else if (state == ST_PARAMETER) {
+                    if (isCTToken(cp)) {
+                        // OK
+                    } else if (cp == ';' || cp == ',') {
+                        // no value
+                        if (i - paramStart == 6 && urlString.regionMatches(true, paramStart, "base64", 0, 6)) {
+                            base64 = true;
+                        } else {
+                            contentTypeBuilder.append(';').append(urlString.substring(paramStart, i));
+                        }
+                        if (cp == ',') {
+                            text = contentTypeBuilder.lastIndexOf("text/", 5) != -1;
+                            if (text && charsetName != null) {
+                                contentTypeBuilder.insert(postCt, ";charset=" + charsetName);
+                            }
+                            contentType = contentTypeBuilder.toString();
+                            content = urlString.offsetByCodePoints(i, 1);
+                            // done
+                            break;
+                        }
+                        paramStart = urlString.offsetByCodePoints(i, 1);
+                        // restart ST_PARAMETER
+                    } else if (cp == '=') {
+                        paramEnd = i;
+                        state = ST_PARAMETER_VAL;
+                    } else {
+                        throw invalidChar(i);
+                    }
+                } else if (state == ST_PARAMETER_VAL) {
+                    if (isCTToken(cp)) {
+                        // OK
+                    } else if (cp == ';' || cp == ',') {
+                        // there is a value
+                        final String value = urlString.substring(paramEnd + 1, i);
+                        if (paramEnd - paramStart == 7 && urlString.regionMatches(true, paramStart, "charset", 0, 7)) {
+                            try {
+                                charset = Charset.forName(value);
+                            } catch (UnsupportedCharsetException e) {
+                                throw e;
+                            } catch (Throwable t) {
+                                final UnsupportedCharsetException uce = new UnsupportedCharsetException(value);
+                                uce.initCause(t);
+                                throw uce;
+                            }
+                            charsetName = value;
+                        } else {
+                            contentTypeBuilder.append(urlString.substring(paramStart, i));
+                        }
+                        if (cp == ',') {
+                            text = contentTypeBuilder.lastIndexOf("text/", 5) != -1;
+                            if (text && charsetName != null) {
+                                contentTypeBuilder.insert(postCt, ";charset=" + charsetName);
+                            }
+                            contentType = contentTypeBuilder.toString();
+                            content = urlString.offsetByCodePoints(i, 1);
+                            // done
+                            break;
+                        }
+                        state = ST_PARAMETER;
+                    } else {
+                        throw invalidChar(i);
+                    }
+                } else {
+                    throw new IllegalStateException();
+                }
+            }
+            if (content == -1) {
+                throw new ProtocolException("Missing content");
+            }
+            // now, get the content
+            byte[] bytes;
+            String str;
+            if (base64) {
+                bytes = Base64.getMimeDecoder().decode(urlString.substring(content).replaceAll("\\s+", ""));
+                if (text) {
+                    str = new String(bytes, charset);
+                } else {
+                    str = null;
+                }
+            } else {
+                if (text) {
+                    str = URLDecoder.decode(urlString.substring(content), charset.name());
+                    bytes = str.getBytes(charset);
+                } else {
+                    // this is a bit hacky...
+                    bytes = URLDecoder.decode(urlString.substring(content), StandardCharsets.ISO_8859_1.name()).getBytes(StandardCharsets.ISO_8859_1);
+                    str = null;
+                }
+            }
+            this.content = bytes;
+            this.contentType = contentType;
+            this.contentString = str;
+        }
+
+        private static ProtocolException invalidChar(int pos) {
+            return new ProtocolException("Invalid character at position " + pos);
+        }
+
+        private static boolean isCTToken(int cp) {
+            return 0x21 <= cp && cp <= 0x7e &&
+                cp != '(' && cp != ')' && cp != '<' && cp != '>' && cp != '@' &&
+                cp != ',' && cp != ';' && cp != ':' && cp != '\\' && cp != '"' &&
+                cp != '/' && cp != '[' && cp != ']' && cp != '?' && cp != '=';
+        }
+
+        public void connect() {
+            connected = true;
+        }
+
+        public int getContentLength() {
+            return content.length;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public Object getContent() {
+            return contentString != null ? contentString : content.clone();
+        }
+
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(content);
+        }
+    }
+}

--- a/src/main/java/org/jboss/modules/ModularURLStreamHandlerFactory.java
+++ b/src/main/java/org/jboss/modules/ModularURLStreamHandlerFactory.java
@@ -98,6 +98,9 @@ final class ModularURLStreamHandlerFactory implements URLStreamHandlerFactory {
                 }
             }
         }
+        if (protocol.equals("data")) {
+            return DataURLStreamHandler.getInstance();
+        }
 
         return null;
     }

--- a/src/main/java/org/jboss/modules/Module.java
+++ b/src/main/java/org/jboss/modules/Module.java
@@ -24,6 +24,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.security.AccessController;
@@ -54,7 +55,6 @@ import org.jboss.modules.filter.PathFilters;
 import org.jboss.modules.log.ModuleLogger;
 import org.jboss.modules.log.NoopModuleLogger;
 
-import __redirected.__JAXPRedirected;
 import org.jboss.modules.security.ModularPermissionFactory;
 
 /**
@@ -93,7 +93,6 @@ public final class Module {
         list.add("sun.reflect.");
         list.add("jdk.internal.reflect.");
         list.add("com.sun.crypto.provider.");
-        list.add("__redirected.");
         if (pkgsString != null) {
             int i;
             int nc = -1;
@@ -133,9 +132,6 @@ public final class Module {
                 } catch (Throwable t) {
                     // todo log a warning or something
                 }
-
-                __JAXPRedirected.initAll();
-
                 return null;
             }
         });
@@ -756,6 +752,10 @@ public final class Module {
                 return resource.getURL();
             }
         }
+        final URLConnectionResource resource = ModuleClassLoader.jaxpImplResources.get(name);
+        if (resource != null) {
+            return resource.getURL();
+        }
         return null;
     }
 
@@ -790,6 +790,10 @@ public final class Module {
             for (Resource resource : resourceList) {
                 return resource.openStream();
             }
+        }
+        final URLConnectionResource resource = ModuleClassLoader.jaxpImplResources.get(name);
+        if (resource != null) {
+            return resource.openStream();
         }
         return null;
     }
@@ -831,6 +835,10 @@ public final class Module {
             for (Resource resource : resourceList) {
                 list.add(resource.getURL());
             }
+        }
+        final URLConnectionResource resource = ModuleClassLoader.jaxpImplResources.get(name);
+        if (resource != null) {
+            list.add(resource.getURL());
         }
 
         return list.size() == 0 ? ConcurrentClassLoader.EMPTY_ENUMERATION : Collections.enumeration(list);

--- a/src/main/java/org/jboss/modules/ModuleClassLoader.java
+++ b/src/main/java/org/jboss/modules/ModuleClassLoader.java
@@ -24,6 +24,17 @@ import java.security.ProtectionDomain;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import __redirected.__DatatypeFactory;
+import __redirected.__DocumentBuilderFactory;
+import __redirected.__SAXParserFactory;
+import __redirected.__SchemaFactory;
+import __redirected.__TransformerFactory;
+import __redirected.__XMLEventFactory;
+import __redirected.__XMLInputFactory;
+import __redirected.__XMLOutputFactory;
+import __redirected.__XMLReaderFactory;
+import __redirected.__XPathFactory;
 import org.jboss.modules.filter.PathFilter;
 import org.jboss.modules.filter.PathFilters;
 import org.jboss.modules.log.ModuleLogger;
@@ -43,6 +54,16 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.xpath.XPathFactory;
+
 /**
  * A module classloader.  Instances of this class implement the complete view of classes and resources available in a
  * module.  Contrast with {@link Module}, which has API methods to access the exported view of classes and resources.
@@ -55,6 +76,9 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class ModuleClassLoader extends ConcurrentClassLoader {
 
+    private static final Map<String, Class<?>> jaxpClassesByName;
+    static final Map<String, URLConnectionResource> jaxpImplResources;
+
     static {
         boolean parallelOk = true;
         try {
@@ -64,6 +88,31 @@ public class ModuleClassLoader extends ConcurrentClassLoader {
         if (! parallelOk) {
             throw new Error("Failed to register " + ModuleClassLoader.class.getName() + " as parallel-capable");
         }
+        Map<String, Class<?>> jaxpMap = new HashMap<>();
+        jaxpMap.put(DatatypeFactory.class.getName(), __DatatypeFactory.class);
+        jaxpMap.put(DocumentBuilderFactory.class.getName(), __DocumentBuilderFactory.class);
+        jaxpMap.put(SAXParserFactory.class.getName(), __SAXParserFactory.class);
+        jaxpMap.put(SchemaFactory.class.getName(), __SchemaFactory.class);
+        jaxpMap.put(TransformerFactory.class.getName(), __TransformerFactory.class);
+        jaxpMap.put(XMLEventFactory.class.getName(), __XMLEventFactory.class);
+        jaxpMap.put(XMLInputFactory.class.getName(), __XMLInputFactory.class);
+        jaxpMap.put(XMLOutputFactory.class.getName(), __XMLOutputFactory.class);
+        jaxpMap.put(__XMLReaderFactory.SAX_DRIVER, __XMLReaderFactory.class);
+        jaxpMap.put(XPathFactory.class.getName(), __XPathFactory.class);
+        Map<String, Class<?>> classesByName = new HashMap<>();
+        Map<String, URLConnectionResource> resources = new HashMap<>();
+        for (Map.Entry<String, Class<?>> entry : jaxpMap.entrySet()) {
+            final Class<?> clazz = entry.getValue();
+            final String clazzName = clazz.getName();
+            classesByName.put(clazzName, clazz);
+            try {
+                resources.put("META-INF/services/" + entry.getKey(), new URLConnectionResource(new URL("data:text/plain;charset=utf-8," + clazzName)));
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        jaxpClassesByName = classesByName;
+        jaxpImplResources = resources;
     }
 
     private final Module module;
@@ -184,6 +233,14 @@ public class ModuleClassLoader extends ConcurrentClassLoader {
             return loadedClass;
         }
         final ModuleLogger log = Module.log;
+        loadedClass = jaxpClassesByName.get(className);
+        if (loadedClass != null) {
+            log.trace("Found jaxp class %s from %s", loadedClass, module);
+            if (resolve) {
+                resolveClass(loadedClass);
+            }
+            return loadedClass;
+        }
         final Module module = this.module;
         log.trace("Finding class %s from %s", className, module);
 
@@ -238,6 +295,14 @@ public class ModuleClassLoader extends ConcurrentClassLoader {
         Class<?> loadedClass = findLoadedClass(className);
         if (loadedClass != null) {
             log.trace("Found previously loaded %s from %s", loadedClass, module);
+            if (resolve) {
+                resolveClass(loadedClass);
+            }
+            return loadedClass;
+        }
+        loadedClass = jaxpClassesByName.get(className);
+        if (loadedClass != null) {
+            log.trace("Found jaxp class %s from %s", loadedClass, module);
             if (resolve) {
                 resolveClass(loadedClass);
             }
@@ -312,18 +377,15 @@ public class ModuleClassLoader extends ConcurrentClassLoader {
         final String path = Module.pathOf(name);
 
         final List<ResourceLoader> loaders = paths.get(path);
-        if (loaders == null) {
-            // no loaders for this path
-            return null;
-        }
-
-        for (ResourceLoader loader : loaders) {
-            if (root.equals(loader.getRootName())) {
-                return loader.getResource(name);
+        if (loaders != null) {
+            for (ResourceLoader loader : loaders) {
+                if (root.equals(loader.getRootName())) {
+                    return loader.getResource(name);
+                }
             }
         }
-
-        return null;
+        // no loaders for this path if it's not in the JAXP map
+        return jaxpImplResources.get(name);
     }
 
     /**
@@ -338,19 +400,20 @@ public class ModuleClassLoader extends ConcurrentClassLoader {
         final String path = Module.pathOf(name);
 
         final List<ResourceLoader> loaders = paths.get(path);
-        if (loaders == null) {
-            // no loaders for this path
-            return Collections.emptyList();
-        }
-
-        final List<Resource> list = new ArrayList<Resource>(loaders.size());
-        for (ResourceLoader loader : loaders) {
-            final Resource resource = loader.getResource(name);
-            if (resource != null) {
-                list.add(resource);
+        final List<Resource> list = new ArrayList<Resource>(loaders == null ? 1 : loaders.size());
+        if (loaders != null) {
+            for (ResourceLoader loader : loaders) {
+                final Resource resource = loader.getResource(name);
+                if (resource != null) {
+                    list.add(resource);
+                }
             }
         }
-        return list.isEmpty() ? Collections.<Resource>emptyList() : list;
+        final URLConnectionResource resource = jaxpImplResources.get(name);
+        if (resource != null) {
+            list.add(resource);
+        }
+        return list.isEmpty() ? Collections.emptyList() : list;
     }
 
     private Class<?> doDefineOrLoadClass(final String className, final byte[] bytes, int off, int len, ProtectionDomain protectionDomain) {
@@ -536,7 +599,7 @@ public class ModuleClassLoader extends ConcurrentClassLoader {
 
     /** {@inheritDoc} */
     @Override
-    public final Enumeration<URL> findResources(final String name, final boolean exportsOnly) throws IOException {
+    public final Enumeration<URL> findResources(final String name, final boolean exportsOnly) {
         return module.getResources(name);
     }
 

--- a/src/main/java/org/jboss/modules/PathResourceLoader.java
+++ b/src/main/java/org/jboss/modules/PathResourceLoader.java
@@ -145,12 +145,7 @@ class PathResourceLoader extends AbstractResourceLoader implements IterableResou
     @Override
     public Resource getResource(final String name) {
         final String cleanName = PathUtils.canonicalize(PathUtils.relativize(name));
-        final Path file;
-        try {
-            file = root.resolve(cleanName);
-        } catch (InvalidPathException ignored) {
-            return null;
-        }
+        final Path file = root.resolve(cleanName);
 
         if (!doPrivilegedIfNeeded(context, () -> Files.exists(file))) {
             return null;
@@ -170,7 +165,7 @@ class PathResourceLoader extends AbstractResourceLoader implements IterableResou
             }
             return Files.walk(path, recursive ? Integer.MAX_VALUE : 1)
                     .filter(it -> !Files.isDirectory(it))
-                    .<Resource>map(resourcePath -> new PathResource(resourcePath, root.relativize(resourcePath).toString(), context))
+                    .<Resource>map(resourcePath -> new PathResource(resourcePath, PathUtils.toGenericSeparators(root.relativize(resourcePath).toString()), context))
                     .iterator();
         } catch (IOException e) {
             return Collections.emptyIterator();
@@ -180,13 +175,11 @@ class PathResourceLoader extends AbstractResourceLoader implements IterableResou
     @Override
     public Collection<String> getPaths() {
         try {
-            final String separator = root.getFileSystem().getSeparator();
-
             return doPrivilegedIfNeeded(context, IOException.class, () -> Files.walk(root)
                     .filter(Files::isDirectory)
                     .map(dir -> {
                         final String result = root.relativize(dir).toString();
-                        final String canonical = separator.equals("/") ? result : result.replace(separator, "/");
+                        final String canonical = PathUtils.toGenericSeparators(result);
 
                         // JBoss modules expect folders not to end with a slash, so we have to strip it.
                         if (canonical.endsWith("/")) {

--- a/src/main/java/org/jboss/modules/PathUtils.java
+++ b/src/main/java/org/jboss/modules/PathUtils.java
@@ -254,6 +254,16 @@ public final class PathUtils {
     }
 
     /**
+     * Get the given path name with OS-specific separators replaced with the generic {@code /} separator character.
+     *
+     * @param original the original string
+     * @return the same string with OS-specific separators replaced with {@code /}
+     */
+    public static String toGenericSeparators(String original) {
+        return File.separatorChar == '/' ? original : original.replace(File.separatorChar, '/');
+    }
+
+    /**
      * Determine whether a path name is relative.
      *
      * @param path the path name

--- a/src/main/java/org/jboss/modules/URLConnectionResource.java
+++ b/src/main/java/org/jboss/modules/URLConnectionResource.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.modules;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+
+/**
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+final class URLConnectionResource implements Resource {
+    private final URLConnection connection;
+
+    URLConnectionResource(final URL url) throws IOException {
+        this.connection = url.openConnection();
+    }
+
+    public String getName() {
+        return getURL().getPath();
+    }
+
+    public URL getURL() {
+        return connection.getURL();
+    }
+
+    public InputStream openStream() throws IOException {
+        return connection.getInputStream();
+    }
+
+    public long getSize() {
+        final long len = connection.getContentLengthLong();
+        return len == -1 ? 0 : len;
+    }
+}

--- a/src/main/java9/__redirected/JDKSpecific.java
+++ b/src/main/java9/__redirected/JDKSpecific.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package __redirected;
+
+import java.util.function.Supplier;
+
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.xpath.XPathFactory;
+
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+final class JDKSpecific {
+
+    static Supplier<DatatypeFactory> getPlatformDatatypeFactorySupplier() {
+        return new Supplier<DatatypeFactory>() {
+            public DatatypeFactory get() {
+                return DatatypeFactory.newDefaultInstance();
+            }
+        };
+    }
+
+    static Supplier<DocumentBuilderFactory> getPlatformDocumentBuilderFactorySupplier() {
+        return new Supplier<DocumentBuilderFactory>() {
+            public DocumentBuilderFactory get() {
+                return DocumentBuilderFactory.newDefaultInstance();
+            }
+        };
+    }
+
+    static Supplier<SAXParserFactory> getPlatformSaxParserFactorySupplier() {
+        return new Supplier<SAXParserFactory>() {
+            public SAXParserFactory get() {
+                return SAXParserFactory.newDefaultInstance();
+            }
+        };
+    }
+
+    static Supplier<SchemaFactory> getPlatformSchemaFactorySupplier() {
+        return new Supplier<SchemaFactory>() {
+            public SchemaFactory get() {
+                return SchemaFactory.newDefaultInstance();
+            }
+        };
+    }
+
+    static Supplier<TransformerFactory> getPlatformSaxTransformerFactorySupplier() {
+        return new Supplier<TransformerFactory>() {
+            public TransformerFactory get() {
+                return TransformerFactory.newDefaultInstance();
+            }
+        };
+    }
+
+    static Supplier<XMLEventFactory> getPlatformXmlEventFactorySupplier() {
+        return new Supplier<XMLEventFactory>() {
+            public XMLEventFactory get() {
+                return XMLEventFactory.newDefaultFactory();
+            }
+        };
+    }
+
+    static Supplier<XMLInputFactory> getPlatformXmlInputFactorySupplier() {
+        return new Supplier<XMLInputFactory>() {
+            public XMLInputFactory get() {
+                return XMLInputFactory.newDefaultFactory();
+            }
+        };
+    }
+
+    static Supplier<XMLOutputFactory> getPlatformXmlOutputFactorySupplier() {
+        return new Supplier<XMLOutputFactory>() {
+            public XMLOutputFactory get() {
+                return XMLOutputFactory.newDefaultFactory();
+            }
+        };
+    }
+
+    static Supplier<XMLReader> getPlatformXmlReaderSupplier() {
+        return new Supplier<XMLReader>() {
+            public XMLReader get() {
+                try {
+                    return SAXParserFactory.newDefaultInstance().newSAXParser().getXMLReader();
+                } catch (SAXException | ParserConfigurationException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+
+    static Supplier<XPathFactory> getPlatformXPathFactorySupplier() {
+        return new Supplier<XPathFactory>() {
+            public XPathFactory get() {
+                return XPathFactory.newDefaultInstance();
+            }
+        };
+    }
+}

--- a/src/main/java9/__redirected/JDKSpecific.java
+++ b/src/main/java9/__redirected/JDKSpecific.java
@@ -119,8 +119,4 @@ final class JDKSpecific {
             }
         };
     }
-
-    static void installDefaultXMLReader() {
-        // no action necessary; Java 9+ correctly loads providers
-    }
 }

--- a/src/main/java9/__redirected/JDKSpecific.java
+++ b/src/main/java9/__redirected/JDKSpecific.java
@@ -119,4 +119,8 @@ final class JDKSpecific {
             }
         };
     }
+
+    static void installDefaultXMLReader() {
+        // no action necessary; Java 9+ correctly loads providers
+    }
 }

--- a/src/main/java9/org/jboss/modules/JDKSpecific.java
+++ b/src/main/java9/org/jboss/modules/JDKSpecific.java
@@ -1,0 +1,233 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.modules;
+
+import static java.nio.file.FileVisitResult.CONTINUE;
+import static java.nio.file.FileVisitResult.SKIP_SUBTREE;
+import static java.security.AccessController.doPrivileged;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import java.util.jar.JarFile;
+
+/**
+ * JDK-specific classes which are replaced for different JDK major versions.  This one is for Java 9 only.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ */
+final class JDKSpecific {
+
+    // === private fields and data ===
+
+    static final Set<String> MODULES_PACKAGES = new HashSet<>(Arrays.asList(
+        "org/jboss/modules",
+        "org/jboss/modules/filter",
+        "org/jboss/modules/log",
+        "org/jboss/modules/management",
+        "org/jboss/modules/ref"
+    ));
+
+    static final StackWalker STACK_WALKER = doPrivileged((PrivilegedAction<StackWalker>) () -> StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE));
+
+    static final ClassLoader SYSTEM_CLASS_LOADER = doPrivileged((PrivilegedAction<ClassLoader>) ClassLoader::getSystemClassLoader);
+    static final ClassLoader OUR_CLASS_LOADER = JDKSpecific.class.getClassLoader();
+
+    // === the actual JDK-specific API ===
+
+    static JarFile getJarFile(final String name, final boolean verify) throws IOException {
+        return new JarFile(new File(name), verify, JarFile.OPEN_READ, JarFile.runtimeVersion());
+    }
+
+    static JarFile getJarFile(final File name, final boolean verify) throws IOException {
+        return new JarFile(name, verify, JarFile.OPEN_READ, JarFile.runtimeVersion());
+    }
+
+    static Class<?> getCallingUserClass() {
+        return STACK_WALKER.walk(stream -> stream.skip(1)
+                .filter(s -> !s.getDeclaringClass().equals(org.jboss.modules.Module.class))
+                .findFirst().get().getDeclaringClass());
+    }
+
+    static Class<?> getCallingClass() {
+        return STACK_WALKER.walk(JDKSpecific::processFrame);
+    }
+
+    static boolean isParallelCapable(ConcurrentClassLoader cl) {
+        return cl.isRegisteredAsParallelCapable();
+    }
+
+    static Package getPackage(ClassLoader cl, String packageName) {
+        return cl.getDefinedPackage(packageName);
+    }
+
+    static Set<String> getJDKPaths() {
+        Set<String> pathSet = new FastCopyHashSet<>(1024);
+        processRuntimeImages(pathSet);
+        // TODO: Remove this stuff once jboss-modules is itself a module
+        final String javaClassPath = AccessController.doPrivileged(new PropertyReadAction("java.class.path"));
+        JDKPaths.processClassPathItem(javaClassPath, new FastCopyHashSet<>(1024), pathSet);
+        pathSet.addAll(MODULES_PACKAGES);
+        return pathSet;
+    }
+
+    static LocalLoader getSystemLocalLoader() {
+        return new LocalLoader() {
+            public Class<?> loadClassLocal(final String name, final boolean resolve) {
+                try {
+                    return Class.forName(name, resolve, getPlatformClassLoader());
+                } catch (ClassNotFoundException ignored) {
+                    try {
+                        return Class.forName(name, resolve, OUR_CLASS_LOADER);
+                    } catch (ClassNotFoundException e) {
+                        return null;
+                    }
+                }
+            }
+
+            public Package loadPackageLocal(final String name) {
+                final Package pkg = getPackage(getPlatformClassLoader(), name);
+                return pkg != null ? pkg : getPackage(OUR_CLASS_LOADER, name);
+            }
+
+            public List<Resource> loadResourceLocal(final String name) {
+                final Enumeration<URL> urls;
+                try {
+                    urls = getSystemResources(name);
+                } catch (IOException e) {
+                    return Collections.emptyList();
+                }
+                final List<Resource> list = new ArrayList<Resource>();
+                while (urls.hasMoreElements()) {
+                    list.add(new URLResource(urls.nextElement()));
+                }
+                return list;
+            }
+        };
+    }
+
+    static ClassLoader getPlatformClassLoader() {
+        return SYSTEM_CLASS_LOADER;
+    }
+
+    static URL getSystemResource(final String name) {
+        final URL resource = getPlatformClassLoader().getResource(name);
+        return resource != null ? resource : OUR_CLASS_LOADER.getResource(name);
+    }
+
+    static Enumeration<URL> getSystemResources(final String name) throws IOException {
+        final Enumeration<URL> resources = getPlatformClassLoader().getResources(name);
+        return resources != null && resources.hasMoreElements() ? resources : OUR_CLASS_LOADER.getResources(name);
+    }
+
+    static InputStream getSystemResourceAsStream(final String name) {
+        final InputStream stream = getPlatformClassLoader().getResourceAsStream(name);
+        return stream != null ? stream : OUR_CLASS_LOADER.getSystemResourceAsStream(name);
+    }
+
+    static Class<?> getSystemClass(@SuppressWarnings("unused") final ConcurrentClassLoader caller, final String className) throws ClassNotFoundException {
+        try {
+            return getPlatformClassLoader().loadClass(className);
+        } catch (ClassNotFoundException ignored) {
+            return OUR_CLASS_LOADER.loadClass(className);
+        }
+    }
+
+    // === nested util stuff, non-API ===
+
+    private static Class<?> processFrame(Stream<StackWalker.StackFrame> stream) {
+        final Iterator<StackWalker.StackFrame> iterator = stream.iterator();
+        if (! iterator.hasNext()) return null;
+        iterator.next();
+        if (! iterator.hasNext()) return null;
+        Class<?> testClass = iterator.next().getDeclaringClass();
+        while (iterator.hasNext()) {
+            final Class<?> item = iterator.next().getDeclaringClass();
+            if (testClass != item) {
+                return item;
+            }
+        }
+        return null;
+    }
+
+    private static void processRuntimeImages(final Set<String> jarSet) {
+        try {
+            for (final Path root : FileSystems.getFileSystem(new URI("jrt:/")).getRootDirectories()) {
+                Files.walkFileTree(root, new JrtFileVisitor(jarSet));
+            }
+        } catch (final URISyntaxException |IOException e) {
+            throw new IllegalStateException("Unable to process java runtime images");
+        }
+    }
+
+    private static class JrtFileVisitor implements FileVisitor<Path> {
+
+        private static final String SLASH = "/";
+        private static final String PACKAGES = "/packages";
+        private final Set<String> pathSet;
+
+        private JrtFileVisitor(final Set<String> pathSet) {
+            this.pathSet = pathSet;
+        }
+
+        @Override
+        public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs) throws IOException {
+            final String d = dir.toString();
+            return d.equals(SLASH) || d.startsWith(PACKAGES) ? CONTINUE : SKIP_SUBTREE;
+        }
+
+        @Override
+        public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+            String f = file.toString();
+            pathSet.add(f.substring(PACKAGES.length() + 1, f.lastIndexOf(SLASH)).replace('.', '/'));
+            return CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFileFailed(final Path file, final IOException exc) throws IOException {
+            return CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
+            return CONTINUE;
+        }
+    }
+}

--- a/src/main/java9/org/jboss/modules/NamedClassLoader.java
+++ b/src/main/java9/org/jboss/modules/NamedClassLoader.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.modules;
+
+/**
+ * A class loader that may be named.  On Java 9 and later, the name will be propagated up to the JVM.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public abstract class NamedClassLoader extends ClassLoader {
+    static {
+        if (! ClassLoader.registerAsParallelCapable()) {
+            throw new Error("Failed to register " + NamedClassLoader.class.getName() + " as parallel-capable");
+        }
+    }
+
+    /**
+     * Construct a new instance.
+     *
+     * @param parent the parent class loader (may be {@code null} to indicate that the platform class loader should be used)
+     * @param name the name, or {@code null} if the class loader has no name
+     */
+    protected NamedClassLoader(final ClassLoader parent, final String name) {
+        super(name, parent == null ? ClassLoader.getPlatformClassLoader() : parent);
+    }
+
+    /**
+     * Construct a new instance.
+     *
+     * @param name the name, or {@code null} if the class loader has no name
+     */
+    protected NamedClassLoader(final String name) {
+        this(null, name);
+    }
+
+    /**
+     * Get the name of this class loader.
+     *
+     * @return the name of this class loader, or {@code null} if it is unnamed
+     */
+    public String getName() {
+        return super.getName();
+    }
+}

--- a/src/main/java9/org/jboss/modules/maven/JDKSpecific.java
+++ b/src/main/java9/org/jboss/modules/maven/JDKSpecific.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.modules.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.jar.JarFile;
+
+/**
+ * JDK-specific classes which are replaced for different JDK major versions.  This one is for Java 9 only.
+ *
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ */
+final class JDKSpecific {
+
+    static JarFile getJarFile(final File name, final boolean verify) throws IOException {
+        return new JarFile(name, verify, JarFile.OPEN_READ, JarFile.runtimeVersion());
+    }
+
+}

--- a/src/main/java9/org/jboss/modules/xml/JDKSpecific.java
+++ b/src/main/java9/org/jboss/modules/xml/JDKSpecific.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.modules.xml;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.jar.JarFile;
+
+/**
+ * JDK-specific classes which are replaced for different JDK major versions.  This one is for Java 9 only.
+ *
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ */
+final class JDKSpecific {
+
+    static JarFile getJarFile(final File name, final boolean verify) throws IOException {
+        return new JarFile(name, verify, JarFile.OPEN_READ, JarFile.runtimeVersion());
+    }
+
+}

--- a/src/test/java/org/jboss/modules/DataURLStreamHandlerTest.java
+++ b/src/test/java/org/jboss/modules/DataURLStreamHandlerTest.java
@@ -1,0 +1,115 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.modules;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+/**
+ */
+public class DataURLStreamHandlerTest {
+    public DataURLStreamHandlerTest() {
+    }
+
+    static URL makeUrl(String str) throws MalformedURLException {
+        return new URL(null, str, DataURLStreamHandler.getInstance());
+    }
+
+    static byte[] readAllBytes(URLConnection uc) throws IOException {
+        final byte[] bytes = new byte[uc.getContentLength()];
+        final InputStream inputStream = uc.getInputStream();
+        if (inputStream.read(bytes) < bytes.length) {
+            throw new IOException("incomplete read");
+        }
+        return bytes;
+    }
+
+    static byte[] bytes(int... vals) {
+        final byte[] bytes = new byte[vals.length];
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) vals[i];
+        }
+        return bytes;
+    }
+
+    @Test
+    public void testEmpty() throws Exception {
+        final URLConnection urlConnection = makeUrl("data:,").openConnection();
+        assertEquals(0, urlConnection.getContentLength());
+        assertEquals("text/plain", urlConnection.getContentType());
+        assertNull(urlConnection.getContentEncoding());
+        assertEquals(-1, urlConnection.getInputStream().read());
+    }
+
+    @Test
+    public void testText() throws Exception {
+        final URLConnection urlConnection = makeUrl("data:,some kinda text").openConnection();
+        assertEquals(15, urlConnection.getContentLength());
+        assertEquals("text/plain", urlConnection.getContentType());
+        assertEquals("some kinda text", new String(readAllBytes(urlConnection), StandardCharsets.US_ASCII));
+    }
+
+    @Test
+    public void testTextUtf8() throws Exception {
+        final URLConnection urlConnection = makeUrl("data:;charset=utf-8,some kïndä tëxt").openConnection();
+        assertEquals(18, urlConnection.getContentLength());
+        assertEquals("text/plain;charset=utf-8", urlConnection.getContentType());
+        assertEquals("some kïndä tëxt", new String(readAllBytes(urlConnection), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testTextUtf8Ascii() throws Exception {
+        final URLConnection urlConnection = makeUrl("data:,some kïndä tëxt").openConnection();
+        assertEquals(15, urlConnection.getContentLength());
+        assertEquals("text/plain", urlConnection.getContentType());
+        assertEquals("some k?nd? t?xt", new String(readAllBytes(urlConnection), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testPlainBinary() throws Exception {
+        final URLConnection urlConnection = makeUrl("data:x-whatever/stuff;charset=utf-8,some kïndä tëxt").openConnection();
+        assertEquals(15, urlConnection.getContentLength());
+        assertEquals("x-whatever/stuff", urlConnection.getContentType());
+        assertEquals("some k�nd� t�xt", new String(readAllBytes(urlConnection), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testRawBinary() throws Exception {
+        final URLConnection urlConnection = makeUrl("data:x-whatever/stuff,%01%02%03%04%05%F0%FF%00").openConnection();
+        assertEquals(8, urlConnection.getContentLength());
+        assertEquals("x-whatever/stuff", urlConnection.getContentType());
+        assertArrayEquals(bytes(0x01, 0x02, 0x03, 0x04, 0x05, 0xf0, 0xff, 0x00), readAllBytes(urlConnection));
+    }
+
+    @Test
+    public void testBase64Binary() throws Exception {
+        final URLConnection urlConnection = makeUrl("data:x-whatever/stuff;base64,dGhpcyBpcyBhIHRlc3QhCg==").openConnection();
+        assertEquals(16, urlConnection.getContentLength());
+        assertEquals("x-whatever/stuff", urlConnection.getContentType());
+        assertArrayEquals("this is a test!\n".getBytes(StandardCharsets.UTF_8), readAllBytes(urlConnection));
+    }
+}

--- a/src/test/java/org/jboss/modules/JAXPModuleTest.java
+++ b/src/test/java/org/jboss/modules/JAXPModuleTest.java
@@ -220,17 +220,17 @@ public class JAXPModuleTest extends AbstractModuleTestCase {
         ClassLoader old = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(cl);
-            checkDom(clazz, true);
-            checkSax(clazz, true);
-            checkTransformer(clazz, true);
-            checkSAXTransformer(clazz, true);
-            checkXPath(clazz, true);
-            checkXmlEvent(clazz, true);
-            checkXmlInput(clazz, true);
-            checkXmlOutput(clazz, true);
-            checkDatatype(clazz, true);
-            checkSchema(clazz, true);
-            checkXMLReader(clazz, true);
+            checkDom(clazz, false, true);
+            checkSax(clazz, false, true);
+            checkTransformer(clazz, false, true);
+            checkSAXTransformer(clazz, false, true);
+            checkXPath(clazz, false, true);
+            checkXmlEvent(clazz, false, true);
+            checkXmlInput(clazz, false, true);
+            checkXmlOutput(clazz, false, true);
+            checkDatatype(clazz, false, true);
+            checkSchema(clazz, false, true);
+            checkXMLReader(clazz, false, true);
         } finally {
             Thread.currentThread().setContextClassLoader(old);
             __JAXPRedirected.restorePlatformFactory();
@@ -245,17 +245,17 @@ public class JAXPModuleTest extends AbstractModuleTestCase {
         try {
             Thread.currentThread().setContextClassLoader(cl);
             Assert.assertTrue(JDKPaths.JDK.contains("javax/xml/parsers"));
-            checkDom(clazz, true);
-            checkSax(clazz, true);
-            checkTransformer(clazz, true);
-            checkSAXTransformer(clazz, true);
-            checkXPath(clazz, true);
-            checkXmlEvent(clazz, true);
-            checkXmlInput(clazz, true);
-            checkXmlOutput(clazz, true);
-            checkDatatype(clazz, true);
-            checkSchema(clazz, true);
-            checkXMLReader(clazz, true);
+            checkDom(clazz, true, true);
+            checkSax(clazz, true, true);
+            checkTransformer(clazz, true, true);
+            checkSAXTransformer(clazz, true, true);
+            checkXPath(clazz, true, true);
+            checkXmlEvent(clazz, true, true);
+            checkXmlInput(clazz, true, true);
+            checkXmlOutput(clazz, true, true);
+            checkDatatype(clazz, true, true);
+            checkSchema(clazz, true, true);
+            checkXMLReader(clazz, true, true);
         } finally {
             Thread.currentThread().setContextClassLoader(old);
         }
@@ -283,17 +283,17 @@ public class JAXPModuleTest extends AbstractModuleTestCase {
         ClassLoader old = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(cl);
-            checkDom(clazz, true);
-            checkSax(clazz, true);
-            checkTransformer(clazz, true);
-            checkSAXTransformer(clazz, true);
-            checkXmlEvent(clazz, true);
-            checkXPath(clazz, true);
-            checkXmlInput(clazz, true);
-            checkXmlOutput(clazz, true);
-            checkDatatype(clazz, true);
-            checkSchema(clazz, true);
-            checkXMLReader(clazz, true);
+            checkDom(clazz, false, true);
+            checkSax(clazz, false, true);
+            checkTransformer(clazz, false, true);
+            checkSAXTransformer(clazz, false, true);
+            checkXmlEvent(clazz, false, true);
+            checkXPath(clazz, false, true);
+            checkXmlInput(clazz, false, true);
+            checkXmlOutput(clazz, false, true);
+            checkDatatype(clazz, false, true);
+            checkSchema(clazz, false, true);
+            checkXMLReader(clazz, false, true);
         } finally {
             unsafe.putObjectVolatile(fieldBase, fieldOffset, oldMl);
             Thread.currentThread().setContextClassLoader(old);
@@ -301,13 +301,16 @@ public class JAXPModuleTest extends AbstractModuleTestCase {
         }
     }
 
-    public void checkDom(Class<?> clazz, boolean fake) throws Exception {
+    public void checkDom(Class<?> clazz, boolean fakeFactory, boolean fakeImpl) throws Exception {
         DocumentBuilder builder = invokeMethod(clazz.newInstance(), "documentBuilder");
         DocumentBuilderFactory factory = invokeMethod(clazz.newInstance(), "documentFactory");
 
-        Assert.assertEquals(__DocumentBuilderFactory.class.getName(), factory.getClass().getName());
-
-        if (fake) {
+        if (fakeFactory) {
+            Assert.assertEquals(FakeDocumentBuilderFactory.class.getName(), factory.getClass().getName());
+        } else {
+            Assert.assertEquals(__DocumentBuilderFactory.class.getName(), factory.getClass().getName());
+        }
+        if (fakeImpl) {
             Assert.assertEquals(FakeDocumentBuilder.class.getName(), builder.getClass().getName());
         } else {
             // Double check that it works
@@ -317,63 +320,72 @@ public class JAXPModuleTest extends AbstractModuleTestCase {
         }
     }
 
-    public void checkSax(Class<?> clazz, boolean fake) throws Exception {
+    public void checkSax(Class<?> clazz, boolean fakeFactory, boolean fakeImpl) throws Exception {
         SAXParser parser = invokeMethod(clazz.newInstance(), "saxParser");
         SAXParserFactory factory = invokeMethod(clazz.newInstance(), "saxParserFactory");
 
-        Assert.assertEquals(__SAXParserFactory.class.getName(), factory.getClass().getName());
-
-        if (fake) {
+        if (fakeFactory) {
+            Assert.assertEquals(FakeSAXParserFactory.class.getName(), factory.getClass().getName());
+        } else {
+            Assert.assertEquals(__SAXParserFactory.class.getName(), factory.getClass().getName());
+        }
+        if (fakeImpl) {
             Assert.assertEquals(FakeSAXParser.class.getName(), parser.getClass().getName());
         } else {
             Assert.assertSame(SAXParserFactory.newInstance().newSAXParser().getClass(), parser.getClass());
         }
     }
 
-    public void checkTransformer(Class<?> clazz, boolean fake) throws Exception {
+    public void checkTransformer(Class<?> clazz, boolean fakeFactory, boolean fakeImpl) throws Exception {
         Transformer parser = invokeMethod(clazz.newInstance(), "transformer");
         TransformerFactory factory = invokeMethod(clazz.newInstance(), "transformerFactory");
 
-        Assert.assertEquals(__TransformerFactory.class.getName(), factory.getClass().getName());
-
-        if (fake) {
+        if (fakeFactory) {
+            Assert.assertEquals(FakeTransformerFactory.class.getName(), factory.getClass().getName());
+        } else {
+            Assert.assertEquals(__TransformerFactory.class.getName(), factory.getClass().getName());
+        }
+        if (fakeImpl) {
             Assert.assertEquals(FakeTransformer.class.getName(), parser.getClass().getName());
         } else {
             Assert.assertSame(TransformerFactory.newInstance().newTransformer().getClass(), parser.getClass());
         }
     }
 
-    public void checkXPath(Class<?> clazz, boolean fake) throws Exception {
+    public void checkXPath(Class<?> clazz, boolean fakeFactory, boolean fakeImpl) throws Exception {
         XPath parser = invokeMethod(clazz.newInstance(), "xpath");
         XPathFactory factory = invokeMethod(clazz.newInstance(), "xpathFactory");
 
-        Assert.assertEquals(__XPathFactory.class.getName(), factory.getClass().getName());
-
-        if (fake) {
+        if (fakeFactory) {
+            Assert.assertEquals(FakeXPathFactory.class.getName(), factory.getClass().getName());
+        } else {
+            Assert.assertEquals(__XPathFactory.class.getName(), factory.getClass().getName());
+        }
+        if (fakeImpl) {
             Assert.assertEquals(FakeXPath.class.getName(), parser.getClass().getName());
         } else {
             Assert.assertSame(XPathFactory.newInstance().newXPath().getClass(), parser.getClass());
         }
     }
 
-    public void checkSchema(Class<?> clazz, boolean fake) throws Exception {
+    public void checkSchema(Class<?> clazz, boolean fakeFactory, boolean fakeImpl) throws Exception {
         Schema parser = invokeMethod(clazz.newInstance(), "schema");
         SchemaFactory factory = invokeMethod(clazz.newInstance(), "schemaFactory");
 
-        Assert.assertEquals(__SchemaFactory.class.getName(), factory.getClass().getName());
-
-        if (fake) {
+        if (fakeFactory) {
+            Assert.assertEquals(FakeSchemaFactory.class.getName(), factory.getClass().getName());
+        } else {
+            Assert.assertEquals(__SchemaFactory.class.getName(), factory.getClass().getName());
+        }
+        if (fakeImpl) {
             Assert.assertEquals(FakeSchema.class.getName(), parser.getClass().getName());
         } else {
             Assert.assertSame(SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema().getClass(), parser.getClass());
         }
     }
 
-    public void checkXMLReader(Class<?> clazz, boolean fake) throws Exception {
+    public void checkXMLReader(Class<?> clazz, boolean fakeFactory, boolean fakeImpl) throws Exception {
         XMLReader parser = invokeMethod(clazz.newInstance(), "xmlReader");
-
-        Assert.assertEquals(__XMLReaderFactory.class.getName(), parser.getClass().getName());
-
 
         Object test = null;
         try {
@@ -381,75 +393,93 @@ public class JAXPModuleTest extends AbstractModuleTestCase {
         } catch (Exception ignore) {
         }
 
-        if (fake) {
+        if (! fakeFactory) {
+            Assert.assertEquals(__XMLReaderFactory.class.getName(), parser.getClass().getName());
+        }
+        if (fakeImpl) {
             Assert.assertEquals("fake-fake-fake", test);
         } else {
-            Assert.assertFalse("fake-fake-fake".equals(test));
+            Assert.assertNotEquals("fake-fake-fake", test);
         }
     }
 
-    public void checkSAXTransformer(Class<?> clazz, boolean fake) throws Exception {
+    public void checkSAXTransformer(Class<?> clazz, boolean fakeFactory, boolean fakeImpl) throws Exception {
         TransformerHandler transformerHandler = invokeMethod(clazz.newInstance(), "transformerHandler");
         TransformerFactory factory = invokeMethod(clazz.newInstance(), "transformerFactory");
 
-        Assert.assertEquals(__TransformerFactory.class.getName(), factory.getClass().getName());
-
-        if (fake) {
+        if (fakeFactory) {
+            Assert.assertEquals(FakeTransformerFactory.class.getName(), factory.getClass().getName());
+        } else {
+            Assert.assertEquals(__TransformerFactory.class.getName(), factory.getClass().getName());
+        }
+        if (fakeImpl) {
             Assert.assertEquals(FakeTransformerHandler.class.getName(), transformerHandler.getClass().getName());
         } else {
             Assert.assertSame(((SAXTransformerFactory) TransformerFactory.newInstance()).newTransformerHandler().getClass(), transformerHandler.getClass());
         }
     }
 
-    public void checkXmlEvent(Class<?> clazz, boolean fake) throws Exception {
+    public void checkXmlEvent(Class<?> clazz, boolean fakeFactory, boolean fakeImpl) throws Exception {
         DTD dtd = invokeMethod(clazz.newInstance(), "eventDTD");
         XMLEventFactory factory = invokeMethod(clazz.newInstance(), "eventFactory");
 
-        Assert.assertEquals(__XMLEventFactory.class.getName(), factory.getClass().getName());
-
-        if (fake) {
+        if (fakeFactory) {
+            Assert.assertEquals(FakeXMLEventFactory.class.getName(), factory.getClass().getName());
+        } else {
+            Assert.assertEquals(__XMLEventFactory.class.getName(), factory.getClass().getName());
+        }
+        if (fakeImpl) {
             Assert.assertEquals(FakeDTD.class.getName(), dtd.getClass().getName());
         } else {
             Assert.assertSame(XMLEventFactory.newInstance().createDTD("blah").getClass(), dtd.getClass());
         }
     }
 
-    public void checkXmlInput(Class<?> clazz, boolean fake) throws Exception {
+    public void checkXmlInput(Class<?> clazz, boolean fakeFactory, boolean fakeImpl) throws Exception {
         String property = invokeMethod(clazz.newInstance(), "inputProperty");
         XMLInputFactory factory = invokeMethod(clazz.newInstance(), "inputFactory");
 
-        Assert.assertEquals(__XMLInputFactory.class.getName(), factory.getClass().getName());
-
-        if (fake) {
+        if (fakeFactory) {
+            Assert.assertEquals(FakeXMLInputFactory.class.getName(), factory.getClass().getName());
+        } else {
+            Assert.assertEquals(__XMLInputFactory.class.getName(), factory.getClass().getName());
+        }
+        if (fakeImpl) {
             Assert.assertEquals(new FakeXMLInputFactory().getProperty("blah"), property);
         } else {
-            Assert.assertFalse(new FakeXMLInputFactory().getProperty("blah").equals(property));
+            Assert.assertNotEquals(new FakeXMLInputFactory().getProperty("blah"), property);
         }
     }
 
-    public void checkXmlOutput(Class<?> clazz, boolean fake) throws Exception {
+    public void checkXmlOutput(Class<?> clazz, boolean fakeFactory, boolean fakeImpl) throws Exception {
         String property = invokeMethod(clazz.newInstance(), "outputProperty");
         XMLOutputFactory factory = invokeMethod(clazz.newInstance(), "outputFactory");
 
-        Assert.assertEquals(__XMLOutputFactory.class.getName(), factory.getClass().getName());
-
-        if (fake) {
+        if (fakeFactory) {
+            Assert.assertEquals(FakeXMLOutputFactory.class.getName(), factory.getClass().getName());
+        } else {
+            Assert.assertEquals(__XMLOutputFactory.class.getName(), factory.getClass().getName());
+        }
+        if (fakeImpl) {
             Assert.assertEquals(new FakeXMLOutputFactory().getProperty("blah"), property);
         } else {
-            Assert.assertFalse(new FakeXMLInputFactory().getProperty("blah").equals(property));
+            Assert.assertNotEquals(new FakeXMLInputFactory().getProperty("blah"), property);
         }
     }
 
-    public void checkDatatype(Class<?> clazz, boolean fake) throws Exception {
+    public void checkDatatype(Class<?> clazz, boolean fakeFactory, boolean fakeImpl) throws Exception {
         Duration duration = invokeMethod(clazz.newInstance(), "duration");
         DatatypeFactory factory = invokeMethod(clazz.newInstance(), "datatypeFactory");
 
-        Assert.assertEquals(__DatatypeFactory.class.getName(), factory.getClass().getName());
-
-        if (fake) {
+        if (fakeFactory) {
+            Assert.assertEquals(FakeDatatypeFactory.class.getName(), factory.getClass().getName());
+        } else {
+            Assert.assertEquals(__DatatypeFactory.class.getName(), factory.getClass().getName());
+        }
+        if (fakeImpl) {
             Assert.assertEquals(new FakeDuration().getSign(), duration.getSign());
         } else {
-            Assert.assertFalse(new FakeDuration().getSign() == duration.getSign());
+            Assert.assertNotEquals(new FakeDuration().getSign(), duration.getSign());
         }
     }
 

--- a/src/test/java/org/jboss/modules/JAXPModuleTest.java
+++ b/src/test/java/org/jboss/modules/JAXPModuleTest.java
@@ -23,7 +23,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
-import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Calendar;
@@ -129,6 +128,7 @@ import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLFilter;
 import org.xml.sax.XMLReader;
+import sun.misc.Unsafe;
 
 /**
  * Tests JAXP, including all of the possible ways to trigger redirection
@@ -244,6 +244,7 @@ public class JAXPModuleTest extends AbstractModuleTestCase {
         ClassLoader old = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(cl);
+            Assert.assertTrue(JDKPaths.JDK.contains("javax/xml/parsers"));
             checkDom(clazz, true);
             checkSax(clazz, true);
             checkTransformer(clazz, true);
@@ -267,13 +268,14 @@ public class JAXPModuleTest extends AbstractModuleTestCase {
      */
     @Test
     public void testMain() throws Throwable {
+        final java.lang.reflect.Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        Unsafe unsafe = (Unsafe) unsafeField.get(null);
         java.lang.reflect.Field field = DefaultBootModuleLoaderHolder.class.getDeclaredField("INSTANCE");
-        java.lang.reflect.Field modifiersField = java.lang.reflect.Field.class.getDeclaredField("modifiers");
-        modifiersField.setAccessible(true);
-        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-        field.setAccessible(true);
         ModuleLoader oldMl = (ModuleLoader) field.get(null);
-        field.set(null, moduleLoader);
+        final Object fieldBase = unsafe.staticFieldBase(field);
+        final long fieldOffset = unsafe.staticFieldOffset(field);
+        unsafe.putObjectVolatile(fieldBase, fieldOffset, moduleLoader);
 
         Main.main(new String[] {"-jaxpmodule", "fake-jaxp", "test-jaxp"});
         ModuleClassLoader cl = moduleLoader.loadModule(ModuleIdentifier.fromString("test-jaxp")).getClassLoader();
@@ -293,7 +295,7 @@ public class JAXPModuleTest extends AbstractModuleTestCase {
             checkSchema(clazz, true);
             checkXMLReader(clazz, true);
         } finally {
-            field.set(null, oldMl);
+            unsafe.putObjectVolatile(fieldBase, fieldOffset, oldMl);
             Thread.currentThread().setContextClassLoader(old);
             __JAXPRedirected.restorePlatformFactory();
         }

--- a/src/test/java/org/jboss/modules/SystemResourcesTest.java
+++ b/src/test/java/org/jboss/modules/SystemResourcesTest.java
@@ -35,7 +35,7 @@ public class SystemResourcesTest  {
     private static final ModuleIdentifier MODULE_A = ModuleIdentifier.fromString("A");
 
     static {
-        System.setProperty("jboss.modules.system.pkgs", "javax.activation");
+        System.setProperty("jboss.modules.system.pkgs", "javax.naming");
     }
 
 
@@ -50,7 +50,7 @@ public class SystemResourcesTest  {
         Module module = moduleLoader.loadModule(MODULE_A);
         ClassLoader cl = module.getClassLoader();
 
-        Enumeration<URL> resources = cl.getResources("javax/activation/DataHandler.class");
+        Enumeration<URL> resources = cl.getResources("javax/naming/Context.class");
         Assert.assertTrue(resources.hasMoreElements());
 
         resources = cl.getResources("javax/sql/RowSet.class");

--- a/src/test/java/org/jboss/modules/test/JAXPCaller.java
+++ b/src/test/java/org/jboss/modules/test/JAXPCaller.java
@@ -52,7 +52,7 @@ public class JAXPCaller {
         try {
             return factory.newDocumentBuilder().newDocument();
         } catch (ParserConfigurationException e) {
-            throw new IllegalStateException();
+            throw new IllegalStateException(e);
         }
     }
 
@@ -64,7 +64,7 @@ public class JAXPCaller {
         try {
             return DocumentBuilderFactory.newInstance().newDocumentBuilder();
         } catch (ParserConfigurationException e) {
-            throw new IllegalStateException();
+            throw new IllegalStateException(e);
         }
     }
 
@@ -76,7 +76,7 @@ public class JAXPCaller {
         try {
             return SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema();
         } catch (SAXException e) {
-            throw new IllegalStateException();
+            throw new IllegalStateException(e);
         }
     }
 
@@ -84,7 +84,7 @@ public class JAXPCaller {
         try {
             return XMLReaderFactory.createXMLReader();
         } catch (SAXException e) {
-            throw new IllegalStateException();
+            throw new IllegalStateException(e);
         }
     }
 
@@ -96,7 +96,7 @@ public class JAXPCaller {
         try {
             return SAXParserFactory.newInstance().newSAXParser();
         } catch (Exception e) {
-            throw new IllegalStateException();
+            throw new IllegalStateException(e);
         }
     }
 
@@ -108,7 +108,7 @@ public class JAXPCaller {
         try {
             return XPathFactory.newInstance().newXPath();
         } catch (Exception e) {
-            throw new IllegalStateException();
+            throw new IllegalStateException(e);
         }
     }
 
@@ -120,7 +120,7 @@ public class JAXPCaller {
         try {
             return transformerFactory().newTransformer();
         } catch (Exception e) {
-            throw new IllegalStateException();
+            throw new IllegalStateException(e);
         }
     }
 
@@ -128,7 +128,7 @@ public class JAXPCaller {
         try {
             return ((SAXTransformerFactory)transformerFactory()).newTransformerHandler();
         } catch (Exception e) {
-            throw new IllegalStateException();
+            throw new IllegalStateException(e);
         }
     }
 
@@ -164,7 +164,7 @@ public class JAXPCaller {
         try {
             return DatatypeFactory.newInstance();
         } catch (DatatypeConfigurationException e) {
-            throw new IllegalStateException();
+            throw new IllegalStateException(e);
         }
     }
 

--- a/src/test/resources/test/modulecontentloader/jaxp/META-INF/services/javax.xml.parsers.SAXParserFactory
+++ b/src/test/resources/test/modulecontentloader/jaxp/META-INF/services/javax.xml.parsers.SAXParserFactory
@@ -1,19 +1,1 @@
-#
-# JBoss, Home of Professional Open Source.
-# Copyright 2014 Red Hat, Inc., and individual contributors
-# as indicated by the @author tags.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 org.jboss.modules.JAXPModuleTest$FakeSAXParserFactory

--- a/src/test/resources/test/modulecontentloader/jaxp/META-INF/services/org.xml.sax.driver
+++ b/src/test/resources/test/modulecontentloader/jaxp/META-INF/services/org.xml.sax.driver
@@ -1,19 +1,1 @@
-#
-# JBoss, Home of Professional Open Source.
-# Copyright 2014 Red Hat, Inc., and individual contributors
-# as indicated by the @author tags.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 org.jboss.modules.JAXPModuleTest$FakeXMLReader


### PR DESCRIPTION
[JBEAP-15434] [MODULES-339] JAXP redirection fails on 8u161, also in embedded scenarios

JBEAP (7.1.z): https://issues.jboss.org/browse/JBEAP-15434

In order to backport MODULES-339 the following upstream issues need to be also backported:

https://issues.jboss.org/browse/MODULES-258 / PR: #145
https://issues.jboss.org/browse/MODULES-323 / PR: #147
https://issues.jboss.org/browse/MODULES-327 / PR: #151
https://issues.jboss.org/browse/MODULES-341 / Commit: 0193a67
https://issues.jboss.org/browse/MODULES-340 / Commit: e0d9377
https://issues.jboss.org/browse/MODULES-339 / PR: #171 
[MODULES-334] Update PathResourceLoader to return names with generic separators / commit: https://github.com/jboss-modules/jboss-modules/commit/1913a84428ab1ef76fa22c2676f1aeafc0d0f50a
