### PR TITLE
Jbeap 15434 2

### DIFF
--- a/src/main/java/org/jboss/modules/ModuleClassLoader.java
+++ b/src/main/java/org/jboss/modules/ModuleClassLoader.java
@@ -364,7 +364,7 @@ public class ModuleClassLoader extends ConcurrentClassLoader {
     }
 
     /**
-     * Load a local resource from a specific root from this module class loader.
+     * Load a local exported resource from a specific root from this module class loader.
      *
      * @param root the root name
      * @param name the resource name
@@ -384,12 +384,11 @@ public class ModuleClassLoader extends ConcurrentClassLoader {
                 }
             }
         }
-        // no loaders for this path if it's not in the JAXP map
-        return jaxpImplResources.get(name);
+        return null;
     }
 
     /**
-     * Load a local resource from this class loader.
+     * Load a local exported resource from this class loader.
      *
      * @param name the resource name
      * @return the list of resources
@@ -408,10 +407,6 @@ public class ModuleClassLoader extends ConcurrentClassLoader {
                     list.add(resource);
                 }
             }
-        }
-        final URLConnectionResource resource = jaxpImplResources.get(name);
-        if (resource != null) {
-            list.add(resource);
         }
         return list.isEmpty() ? Collections.emptyList() : list;
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-15434

These 2 upstream commits looks like they got missed: 

commit 9722e646263a1f9279279a2e48a43856d0d64679
Author: David M. Lloyd <david.lloyd@redhat.com>
Date:   Tue Mar 20 08:16:15 2018 -0500

    [MODULES-339] Do not export JAXP resources

commit ce0e6d77d42cf9927baf67d7c1eaec85a850515b
Author: David M. Lloyd <david.lloyd@redhat.com>
Date:   Tue Mar 20 08:12:05 2018 -0500

    [MODULES-339] Load all JAXP resources instead of just the first one
    
    (in case the first one does not contain any valid classes)
