### PR TITLE
[MODULES-372] provide our own "java.se" module on JDK 9+

### DIFF
--- a/src/main/java/org/jboss/modules/JDKModuleFinder.java
+++ b/src/main/java/org/jboss/modules/JDKModuleFinder.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -42,36 +41,6 @@ public final class JDKModuleFinder implements IterableModuleFinder {
 
     private final ConcurrentHashMap<String, FutureSpec> modules = new ConcurrentHashMap<>();
     private final List<String> moduleNames;
-
-    static final class SEDeps {
-        static final List<DependencySpec> javaSeDeps;
-
-        static {
-            List<DependencySpec> deps = new ArrayList<>();
-            for (String dep : Arrays.asList(
-                "java.compiler",
-                "java.datatransfer",
-                "java.desktop",
-                "java.instrument",
-                "java.logging",
-                "java.management",
-                "java.management.rmi",
-                "java.naming",
-                "java.prefs",
-                "java.rmi",
-                "java.scripting",
-                "java.security.jgss",
-                "java.security.sasl",
-                "java.sql",
-                "java.sql.rowset",
-                "java.xml",
-                "java.xml.crypto"
-            )) {
-                deps.add(new ModuleDependencySpecBuilder().setName(dep).setExport(true).build());
-            }
-            javaSeDeps = deps;
-        }
-    }
 
     private static final JDKModuleFinder INSTANCE = new JDKModuleFinder();
 
@@ -148,8 +117,8 @@ public final class JDKModuleFinder implements IterableModuleFinder {
             } else {
                 switch (name) {
                     case "java.se": {
-                        final ModuleSpec.Builder builder = ModuleSpec.build("java.se", false);
-                        for (DependencySpec dep : SEDeps.javaSeDeps) {
+                        final ModuleSpec.Builder builder = ModuleSpec.build(name, false);
+                        for (DependencySpec dep : JavaSeDeps.list) {
                             builder.addDependency(dep);
                         }
                         futureSpec.setModuleSpec(builder.create());

--- a/src/main/java/org/jboss/modules/JavaSeDeps.java
+++ b/src/main/java/org/jboss/modules/JavaSeDeps.java
@@ -1,0 +1,35 @@
+package org.jboss.modules;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+final class JavaSeDeps {
+    static final List<DependencySpec> list;
+
+    static {
+        List<DependencySpec> deps = new ArrayList<>();
+        for (String dep : Arrays.asList(
+                "java.compiler",
+                "java.datatransfer",
+                "java.desktop",
+                "java.instrument",
+                "java.logging",
+                "java.management",
+                "java.management.rmi",
+                "java.naming",
+                "java.prefs",
+                "java.rmi",
+                "java.scripting",
+                "java.security.jgss",
+                "java.security.sasl",
+                "java.sql",
+                "java.sql.rowset",
+                "java.xml",
+                "java.xml.crypto"
+        )) {
+            deps.add(new ModuleDependencySpecBuilder().setName(dep).setExport(true).build());
+        }
+        list = deps;
+    }
+}

--- a/src/main/java9/org/jboss/modules/JDKModuleFinder.java
+++ b/src/main/java9/org/jboss/modules/JDKModuleFinder.java
@@ -50,6 +50,15 @@ public final class JDKModuleFinder implements IterableModuleFinder {
     }
 
     public ModuleSpec findModule(final String name, final ModuleLoader delegateLoader) {
+        if ("java.se".equals(name)) {
+            // provide our own "java.se" aggregator module, as the one in JDK isn't accessible by default
+            final ModuleSpec.Builder builder = ModuleSpec.build(name, false);
+            for (DependencySpec dep : JavaSeDeps.list) {
+                builder.addDependency(dep);
+            }
+            return builder.create();
+        }
+
         final Set<String> packages;
         final Module module;
         if ("org.jboss.modules".equals(name)) {


### PR DESCRIPTION
The `java.se` module in JDK 9+ isn't "available" by default. However,
it's merely an aggregator of other modules that _are_ "available".
This commit provides our own `java.se` module even on JDK 9+, instead
of delegating to JPMS. The new `java.se` module aggregates the same
modules as the `java.se` module in the JDK, the only difference is
that it's constructed on the JBoss Modules level and hence doesn't
require users to start JVM with `--add-modules java.se`.