### PR TITLE
MODULES-392 Dynamically determine the dependencies required by the java.se module

### DIFF
--- a/src/main/java9/org/jboss/modules/JavaSeDeps.java
+++ b/src/main/java9/org/jboss/modules/JavaSeDeps.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.modules;
+
+import java.lang.module.ModuleDescriptor;
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReference;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Forms a list of {@link DependencySpec} which represent the dependencies of the "java.se"
+ * module
+ */
+final class JavaSeDeps {
+    static final List<DependencySpec> list;
+
+    static {
+        final Optional<ModuleReference> javaSe = ModuleFinder.ofSystem().find("java.se");
+        final ModuleDescriptor javaSeDescriptor = javaSe.isPresent() ? javaSe.get().descriptor() : null;
+        if (javaSeDescriptor == null) {
+            // this shouldn't happen ever, since Java 9+ always has the java.se module.
+            // But, if it does happen for some reason, we tolerate it and use an empty
+            // DependencySpec
+            list = Collections.emptyList();
+        } else {
+            final List<DependencySpec> deps = new ArrayList<>();
+            for (final ModuleDescriptor.Requires dep : javaSeDescriptor.requires()) {
+                deps.add(new ModuleDependencySpecBuilder().setName(dep.name()).setExport(true).build());
+            }
+            list = Collections.unmodifiableList(deps);
+        }
+    }
+}

--- a/src/test/java/org/jboss/modules/JDKModuleLoaderTest.java
+++ b/src/test/java/org/jboss/modules/JDKModuleLoaderTest.java
@@ -20,6 +20,7 @@ package org.jboss.modules;
 
 import java.net.URL;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 /**
@@ -30,5 +31,27 @@ public class JDKModuleLoaderTest extends AbstractModuleTestCase {
         final Module module = Module.getSystemModuleLoader().loadModule("org.jboss.modules");
         final URL resource = module.getClassLoader().getResource("org/jboss/modules/Main.class");
         Assert.assertNotNull("Main.class", resource);
+    }
+
+    /**
+     * Tests that loading of "java.se" module works and classes that are present
+     * in modules "required" by this "java.se" module can be loaded too
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testJavaSeModuleLoad() throws Exception {
+        final Module module = Module.getBootModuleLoader().loadModule("java.se");
+        Assert.assertNotNull("java.se module not found", module);
+        final String resultSetClassName = "java.sql.ResultSet";
+        final Class<?> klass = module.getClassLoader().loadClass(resultSetClassName);
+        Assert.assertNotNull(resultSetClassName + " class couldn't be loaded from java.se module", klass);
+
+        // test a class that was introduced in Java 11
+        Assume.assumeTrue("Java 11 is required to test loading of classes " +
+                "in java.net.http module", Integer.parseInt(System.getProperty("java.specification.version")) >= 11);
+        final String httpClientClassName = "java.net.http.HttpClient";
+        final Class<?> httpClientClass = module.getClassLoader().loadClass(httpClientClassName);
+        Assert.assertNotNull(httpClientClassName + " class couldn't be loaded from java.se module", httpClientClass);
     }
 }


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/MODULES-392. This commit introduces a multi-release jar specific `JavaSeDeps` which is capable of using Java 9+ modules APIs to dynamically fetch the dependencies "required" by the "java.se" module.

The commit also includes a test case which reproduces the issue noted in the JIRA and verifies this fix.