### PR TITLE
[MODULES-393] Implement a proxy for any log manager which includes a ModuleFinder and a ModuleFinderFactory

### DIFF
--- a/src/main/java/org/jboss/modules/JDKSpecific.java
+++ b/src/main/java/org/jboss/modules/JDKSpecific.java
@@ -185,6 +185,14 @@ final class JDKSpecific {
         list.add("jdk.internal.reflect.");
     }
 
+    static String getJdkModuleNameOf(final Class<?> clazz) {
+        return null;
+    }
+
+    static String getJdkModuleVersionOf(final Class<?> clazz) {
+        return null;
+    }
+
     // === nested util stuff, non-API ===
 
     static final class Hack extends SecurityManager {

--- a/src/main/java/org/jboss/modules/SecurityActions.java
+++ b/src/main/java/org/jboss/modules/SecurityActions.java
@@ -66,4 +66,17 @@ final class SecurityActions {
             return currentThread().getContextClassLoader();
         }
     }
+
+    static ClassLoader getClassLoaderOf(Class<?> clazz) {
+        final SecurityManager sm = getSecurityManager();
+        if (sm != null) {
+            return doPrivileged(new PrivilegedAction<ClassLoader>() {
+                public ClassLoader run() {
+                    return clazz.getClassLoader();
+                }
+            });
+        } else {
+            return clazz.getClassLoader();
+        }
+    }
 }

--- a/src/main/java9/org/jboss/modules/JDKSpecific.java
+++ b/src/main/java9/org/jboss/modules/JDKSpecific.java
@@ -25,6 +25,7 @@ import static java.security.AccessController.doPrivileged;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.module.ModuleDescriptor;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -186,6 +187,17 @@ final class JDKSpecific {
 
     static void addInternalPackages(final List<String> list) {
         // none in Java 9+
+    }
+
+    static String getJdkModuleNameOf(final Class<?> clazz) {
+        final java.lang.Module module = clazz.getModule();
+        return module.isNamed() ? module.getName() : null;
+    }
+
+    static String getJdkModuleVersionOf(final Class<?> clazz) {
+        final java.lang.Module module = clazz.getModule();
+        final ModuleDescriptor.Version version = module.isNamed() ? module.getDescriptor().version().orElse(null) : null;
+        return version == null ? null : version.toString();
     }
 
     // === nested util stuff, non-API ===

--- a/src/test/java/org/jboss/modules/JDKModuleLoaderTest.java
+++ b/src/test/java/org/jboss/modules/JDKModuleLoaderTest.java
@@ -19,6 +19,9 @@
 package org.jboss.modules;
 
 import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -48,8 +51,11 @@ public class JDKModuleLoaderTest extends AbstractModuleTestCase {
         Assert.assertNotNull(resultSetClassName + " class couldn't be loaded from java.se module", klass);
 
         // test a class that was introduced in Java 11
+        String version = System.getProperty("java.specification.version");
+        final Matcher matcher = Pattern.compile("^(?:1\\.)?(\\d+)$").matcher(version);
+        Assume.assumeTrue(matcher.find());
         Assume.assumeTrue("Java 11 is required to test loading of classes " +
-                "in java.net.http module", Integer.parseInt(System.getProperty("java.specification.version")) >= 11);
+                "in java.net.http module", Integer.parseInt(matcher.group(1)) >= 11);
         final String httpClientClassName = "java.net.http.HttpClient";
         final Class<?> httpClientClass = module.getClassLoader().loadClass(httpClientClassName);
         Assert.assertNotNull(httpClientClassName + " class couldn't be loaded from java.se module", httpClientClass);


### PR DESCRIPTION
https://issues.jboss.org/browse/MODULES-393
https://issues.jboss.org/browse/MODULES-394

This relates to [LOGMGR-261](https://issues.jboss.org/browse/LOGMGR-261) and [WFCORE-4674](https://issues.jboss.org/browse/WFCORE-4674) and having the JBoss Log Manager on the boot class path. This is a bit of a hack to use a proxy and implement an interface that [LOGMGR-261](https://issues.jboss.org/browse/LOGMGR-261) will introduce. For better or worse, the reviewer can decide :), I've implemented this in a way where it could be used with any log manager. Not that there likely will be others, but it was easy enough to do so I did it.

The MODULES-394 fix is just a test fix for a failing test when running against Java 8.