### PR TITLE
Fix compilation error on JDK 13

### DIFF
--- a/src/test/java/org/jboss/modules/PathResourceLoaderTest.java
+++ b/src/test/java/org/jboss/modules/PathResourceLoaderTest.java
@@ -77,7 +77,7 @@ public class PathResourceLoaderTest extends AbstractResourceLoaderTestCase {
                 outputFile.getParentFile().mkdirs();
                 JarResourceLoaderTest.buildJar(super.getResourceRoot(test).toFile(), outputFile);
 
-                FileSystem fileSystem = FileSystems.newFileSystem(outputFile.toPath(), null);
+                FileSystem fileSystem = FileSystems.newFileSystem(outputFile.toPath(), (ClassLoader) null);
                 return fileSystem.getRootDirectories().iterator().next();
             }
         };


### PR DESCRIPTION
In JDK 13 `newFileSystem(java.nio.file.Path, java.util.Map)` was added to `java.nio.file.FileSystems`. Fix compilation by casting `null` to `ClassLoader` so the compiler calls `newFileSystem(java.nio.file.Path, java.lang.ClassLoader)`