### PR TITLE
Fixed MavenResourceTest.testDefaultRepositories

### DIFF
--- a/src/test/java/org/jboss/modules/MavenResource2Test.java
+++ b/src/test/java/org/jboss/modules/MavenResource2Test.java
@@ -18,27 +18,24 @@
 
 package org.jboss.modules;
 
-import java.io.File;
-import java.net.URL;
-
-import org.jboss.modules.maven.ArtifactCoordinates;
-import org.jboss.modules.maven.MavenArtifactUtil;
 import org.jboss.modules.maven.MavenSettingsTest;
 import org.jboss.modules.util.Util;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.net.URL;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class MavenResourceTest {
+public class MavenResource2Test {
 
-    protected static final ModuleIdentifier MODULE_ID = ModuleIdentifier.fromString("test.maven");
+    protected static final ModuleIdentifier MODULE_ID2 = ModuleIdentifier.fromString("test.maven:non-main");
 
     @Rule
     public TemporaryFolder tmpdir = new TemporaryFolder();
@@ -52,30 +49,16 @@ public class MavenResourceTest {
     }
 
     @Test
-    public void testWithPassedRepository() throws Exception {
-        System.setProperty("maven.repo.local", tmpdir.newFolder("repository").getAbsolutePath());
-        System.setProperty("remote.maven.repo", "https://repository.jboss.org/nexus/content/groups/public/,https://maven-central.storage.googleapis.com/");
+    public void testDefaultRepositories() throws Exception {
         try {
-            Module module = moduleLoader.loadModule(MODULE_ID);
+            URL settingsXmlUrl = MavenSettingsTest.class.getResource("jboss-settings.xml");
+            System.setProperty("jboss.modules.settings.xml.url", settingsXmlUrl.toExternalForm());
+            Module module = moduleLoader.loadModule(MODULE_ID2);
             URL url = module.getResource("org/jboss/resteasy/plugins/providers/jackson/ResteasyJacksonProvider.class");
             System.out.println(url);
             Assert.assertNotNull(url);
         } finally {
-            System.clearProperty("maven.repo.local");
-            System.clearProperty("remote.repository");
+            System.clearProperty("jboss.modules.settings.xml.url");
         }
-    }
-
-    /**
-     * we test if it uses repostiory user has configured in user.home/.m2/settings.xml or M2_HOME/conf/settings.xml
-     *
-     * @throws Exception
-     */
-    @Test
-    @Ignore("Test is mostly meant for manual testing, as snapshot are not parmanent")
-    public void testCustomRepository() throws Exception {
-        File f = MavenArtifactUtil.resolveJarArtifact(ArtifactCoordinates.fromString("org.wildfly.core:wildfly-version:2.0.5.Final-20151222.144931-1"));
-        Assert.assertNotNull("Should resolve", f);
-        System.out.println("f = " + f);
     }
 }


### PR DESCRIPTION
With forkMode always surefire executes each test class in its own jvm. When running `MavenResourceTest` the first test sets up `MavenSettings`. As a consequence `xerces:xercesImpl:2.9.1-jbossas-2` fails to resolve in `testDefaultRepositories`. Solve this by moving `testDefaultRepositories` to its own test class.