### PR TITLE
[MODULES-393] Introductory agent mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,10 @@
                             <Multi-Release>true</Multi-Release>
                             <Jar-Version>${project.version}</Jar-Version>
                             <Jar-Name>${project.artifactId}</Jar-Name>
+                            <Agent-Class>org.jboss.modules.ModularAgent</Agent-Class>
+                            <Premain-Class>org.jboss.modules.ModularAgent</Premain-Class>
+                            <Can-Redefine-Classes>true</Can-Redefine-Classes>
+                            <Can-Retransform-Classes>true</Can-Retransform-Classes>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/src/main/java/org/jboss/modules/ModularAgent.java
+++ b/src/main/java/org/jboss/modules/ModularAgent.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.modules;
+
+import java.lang.instrument.Instrumentation;
+
+/**
+ * The modular agent entry point.
+ */
+public final class ModularAgent {
+    public static void premain(String agentArgs, Instrumentation instrumentation) {
+        agentmain(agentArgs, instrumentation);
+    }
+
+    public static void agentmain(String agentArgs, Instrumentation instrumentation) {
+        Main.instrumentation = instrumentation;
+    }
+}


### PR DESCRIPTION
Introduce a simple agent mode for JBoss Modules.

- Enable agent mode by adding `-javaagent:jboss-modules.jar` to the JVM's arguments
- Add agents to the run time by adding `-javaagent:your-agent.jar` to the arguments of JBoss Modules
- Agent arguments are not supported yet
- It only works if JBoss Modules was added as an agent per the first step, but in the future a self-attach mode could be supported as well