### PR TITLE
[MODULES-406] IllegalArgumentException when iterating modules if module-absent is present

### DIFF
--- a/src/main/java/org/jboss/modules/LocalModuleFinder.java
+++ b/src/main/java/org/jboss/modules/LocalModuleFinder.java
@@ -297,11 +297,13 @@ public final class LocalModuleFinder implements IterableModuleFinder, AutoClosea
                         }
                         try (InputStream stream = Files.newInputStream(nextPath)) {
                             final ModuleSpec moduleSpec = ModuleXmlParser.parseModuleXml(ModuleXmlParser.ResourceRootFactory.getDefault(), nextPath.getParent().toString(), stream, nextPath.toString(), delegateLoader, (String)null);
-                            this.next = moduleSpec.getName();
-                            if (found.add(this.next)) {
-                                return true;
+                            if (moduleSpec != null) {
+                                this.next = moduleSpec.getName();
+                                if (found.add(this.next)) {
+                                    return true;
+                                }
+                                this.next = null;
                             }
-                            this.next = null;
                         } catch (IOException | ModuleLoadException e) {
                             // ignore
                         }

--- a/src/main/java/org/jboss/modules/xml/ModuleXmlParser.java
+++ b/src/main/java/org/jboss/modules/xml/ModuleXmlParser.java
@@ -584,7 +584,7 @@ public final class ModuleXmlParser {
         String name = null;
         String slot = null;
         boolean noSlots = atLeast1_6(reader);
-        final Set<String> required = new HashSet<>(LIST_A_NAME_A_SLOT);
+        final Set<String> required = noSlots ? new HashSet<>(LIST_A_NAME) : new HashSet<>(LIST_A_NAME_A_SLOT);
         for (int i = 0; i < count; i ++) {
             validateAttributeNamespace(reader, i);
             final String attribute = reader.getAttributeName(i);
@@ -598,13 +598,15 @@ public final class ModuleXmlParser {
         if (! required.isEmpty()) {
             throw missingAttributes(reader, required);
         }
-        if (noSlots) {
-            if (! name.equals(moduleName)) {
-                throw invalidModuleName(reader, moduleName);
-            }
-        } else {
-            if (! ModuleIdentifier.fromString(moduleName).equals(ModuleIdentifier.create(name, slot))) {
-                throw invalidModuleName(reader, moduleName);
+        if (moduleName != null) {
+            if (noSlots) {
+                if (!name.equals(moduleName)) {
+                    throw invalidModuleName(reader, moduleName);
+                }
+            } else {
+                if (!ModuleIdentifier.fromString(moduleName).equals(ModuleIdentifier.create(name, slot))) {
+                    throw invalidModuleName(reader, moduleName);
+                }
             }
         }
         int eventType;

--- a/src/test/java/org/jboss/modules/LocalModuleLoaderTest.java
+++ b/src/test/java/org/jboss/modules/LocalModuleLoaderTest.java
@@ -22,7 +22,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.Iterator;
 
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -73,5 +75,26 @@ public class LocalModuleLoaderTest extends AbstractModuleTestCase {
         assertNotNull(moduleLoader.loadModule(ModuleIdentifier.fromString("test.circular-deps-B")));
         assertNotNull(moduleLoader.loadModule(ModuleIdentifier.fromString("test.circular-deps-C")));
         assertNotNull(moduleLoader.loadModule(ModuleIdentifier.fromString("test.circular-deps-D")));
+    }
+
+    @Test
+    public void testAbsentModule() throws Exception {
+        try {
+            moduleLoader.loadModule("test.absent");
+            fail("Should have thrown a ModuleNotFoundException");
+        } catch(ModuleNotFoundException expected) {}
+    }
+
+    @Test
+    public void testIterateModules() throws Exception {
+        Iterator<String> names = moduleLoader.iterateModules((String) null, true);
+        while (names.hasNext()) {
+            String name = names.next();
+            assertNotEquals("test.absent", name);
+            if (!name.equals("test.bad-deps")) {
+                Module module = moduleLoader.loadModule(name);
+                assertNotNull(module);
+            }
+        }
     }
 }

--- a/src/test/resources/test/repo/test/absent/main/module.xml
+++ b/src/test/resources/test/repo/test/absent/main/module.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2021 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<module-absent xmlns="urn:jboss:module:1.2" name="test.absent" slot="main"/>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/MODULES-406

Three little issues fixed when iterating modules if an `absent-module` is present:

1.  In the `LocalModuleFinder` class the returned `moduleSpec` can be null if it's an absent-module. Just adding the the null check.
2. When reading an absent-module the `required` property was not initialized OK if the xml version is 1.6+.
3. The `moduleName` passed to the `parseModuleAbsentContents` can be null and it should not be compared with the found one in that case (it seems that this check was added to the other parse methods but not for this one).

@ropalka Please review this PR when you have time.