### PR TITLE
MODULES-423: ensure URLStreamHandler intialization for dependency tree

### DIFF
--- a/src/main/java/org/jboss/modules/Main.java
+++ b/src/main/java/org/jboss/modules/Main.java
@@ -302,16 +302,6 @@ public final class Main {
             System.exit(1);
         }
 
-        if (depTree) {
-            DependencyTreeViewer.print(new PrintWriter(System.out), nameArgument, LocalModuleFinder.getRepoRoots(true));
-            System.exit(0);
-        }
-
-        if(debuglog) {
-            // Install the StreamModuleLogger on System.out to capture bootstrap messages
-            Module.setModuleLogger(new StreamModuleLogger(System.out));
-        }
-
         final ModuleLoader loader;
         final ModuleLoader environmentLoader;
         environmentLoader = DefaultBootModuleLoaderHolder.INSTANCE;
@@ -348,6 +338,16 @@ public final class Main {
             }
         }
         Module.initBootModuleLoader(environmentLoader);
+
+        if (depTree) {
+            DependencyTreeViewer.print(new PrintWriter(System.out), nameArgument, LocalModuleFinder.getRepoRoots(true));
+            System.exit(0);
+        }
+
+        if(debuglog) {
+            // Install the StreamModuleLogger on System.out to capture bootstrap messages
+            Module.setModuleLogger(new StreamModuleLogger(System.out));
+        }
 
         if (moduleName == null) {
             return;


### PR DESCRIPTION
Issue: [MODULES-423](https://issues.redhat.com/browse/MODULES-423)

The `Module.initBootModuleLoader(environmentLoader);` (or anything else that would execute the [static block in Module](https://github.com/jboss-modules/jboss-modules/blob/fa4a2e52e75c63d664624964fac64a4a5a75e2a2/src/main/java/org/jboss/modules/Module.java#L120-L134)) needs to happen before the DependencyTreeViewer is executed