### PR TITLE
Large deployments cause a corresponding number of allocations during canonicalize

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.36</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.36</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <licenses>
         <license>
             <name>Apache License 2.0</name>
-            <url>http://:y.jboss.org/licenses/apache-2.0.txt</url>
+            <url>http://repository.jboss.org/licenses/apache-2.0.txt</url>
             <distribution>repo</distribution>
         </license>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
                             <execution>
                                 <id>default-test</id>
                                 <configuration>
+                                    <argLine>-Xmx2048m -Xms2048m</argLine>
                                     <includes>
                                         <include>**/BenchmarkSuite*</include>
                                     </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <licenses>
         <license>
             <name>Apache License 2.0</name>
-            <url>http://repository.jboss.org/licenses/apache-2.0.txt</url>
+            <url>http://:y.jboss.org/licenses/apache-2.0.txt</url>
             <distribution>repo</distribution>
         </license>
         <license>
@@ -74,6 +74,31 @@
                                 </goals>
                                 <configuration>
                                     <jvm>${java8.home}/bin/java</jvm>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>benchmark</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <configuration>
+                                    <includes>
+                                        <include>**/BenchmarkSuite*</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>**/*Test*</exclude>
+                                    </excludes>
                                 </configuration>
                             </execution>
                         </executions>
@@ -140,7 +165,7 @@
             <!-- Compiler -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0-jboss-1</version>
+                <version>3.8.1-jboss-1</version>
                 <executions>
                     <execution>
                         <id>default-compile</id>
@@ -192,9 +217,6 @@
                      <!-- Modules ignores Class-Path -->
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <printSummary>true</printSummary>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
                     <forkMode>always</forkMode>
                 </configuration>
                 <executions>
@@ -202,6 +224,12 @@
                         <id>default-test</id>
                         <configuration>
                             <classesDirectory>${project.build.directory}/classes/META-INF/versions/9</classesDirectory>
+                            <excludes>
+                                <exclude>**/*Benchmark*</exclude>
+                            </excludes>
+                            <includes>
+                                <include>**/*Test.java</include>
+                            </includes>
                             <additionalClasspathElements>
                                 <additionalClasspathElement>${project.build.directory}/classes</additionalClasspathElement>
                             </additionalClasspathElements>

--- a/src/main/java/org/jboss/modules/PathUtils.java
+++ b/src/main/java/org/jboss/modules/PathUtils.java
@@ -266,10 +266,6 @@ public final class PathUtils {
                             if (state == 3) {
                                 targetBuf[a--] = '/';
                             }
-//                            if (pathBuf == null) {
-//                                pathBuf = path.toCharArray();
-//                            }
-//                            System.arraycopy(pathBuf, newE + 1, targetBuf, (a -= segmentLength) + 1, segmentLength);
                             path.getChars(newE + 1, e, targetBuf, (a -= segmentLength) + 1);
                         }
                     }

--- a/src/main/java/org/jboss/modules/PathUtils.java
+++ b/src/main/java/org/jboss/modules/PathUtils.java
@@ -154,14 +154,10 @@ public final class PathUtils {
     static char[] getBuffer(final int length) {
         char[] current = CHAR_BUFFER_CACHE.get();
         if(current == null || current.length < length) {
-            // since we can't shift left from the max value it will hold at the max value
-            // the length is checked against the min value and the min value is just returned if it is too low
-            // the shifting logic finds out how many powers of two we need to shift left to get to the next power of two
-            // requesting a size that is already a power of two will give you that same power of two
-            // because we get the same power of two we use a Math.max on the inner value to make sure we always meet the minimum
-            final int nextLength = length == Integer.MAX_VALUE ? Integer.MAX_VALUE
-                                : length <= MIN_LENGTH ? MIN_LENGTH
-                                : 1 << (Integer.SIZE - Integer.numberOfLeadingZeros(length - 1));
+            // for any value less than the minimum length use the minimum length
+            // for any value greater subtract one, then shift only the highest bit left one
+            // (this is the next greater power of two unless already a power of two where it will be the same)
+            final int nextLength = length <= MIN_LENGTH ? MIN_LENGTH : Integer.highestOneBit(length - 1) << 1;
             current = new char[nextLength];
             CHAR_BUFFER_CACHE.set(current);
         }

--- a/src/test/java/org/jboss/modules/BenchmarkSuite.java
+++ b/src/test/java/org/jboss/modules/BenchmarkSuite.java
@@ -1,0 +1,13 @@
+package org.jboss.modules;
+
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    PathUtilsBenchmarkTest.class
+})
+public class BenchmarkSuite {
+
+}

--- a/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
+++ b/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
@@ -65,82 +65,82 @@ public class PathUtilsBenchmarkTest {
         new Runner(opt).run();
     }
 
-//    @Benchmark
-//    public void noChangeString(Blackhole bh) {
-//        bh.consume(PathUtils.canonicalize(NO_CHANGE_STRING));
-//    }
-//
-//    @Benchmark
-//    public void directNoChangeString(Blackhole bh) {
-//        bh.consume(PathUtils.directCanonicalize(NO_CHANGE_STRING));
-//    }
-//
-//    @Benchmark
-//    public void originalNoChangeString(Blackhole bh) {
-//        bh.consume(PathUtilsTest.originalCanonicalize(NO_CHANGE_STRING));
-//    }
-//
-//    @Benchmark
-//    public void changeString(Blackhole bh) {
-//        bh.consume(PathUtils.canonicalize(CHANGE_STRING));
-//    }
-//
-//    @Benchmark
-//    public void directChangeString(Blackhole bh) {
-//        bh.consume(PathUtils.directCanonicalize(CHANGE_STRING));
-//    }
-//
-//    @Benchmark
-//    public void originalChangeString(Blackhole bh) {
-//        bh.consume(PathUtilsTest.originalCanonicalize(CHANGE_STRING));
-//    }
-//
-//
-//    @Benchmark
-//    public void manyChangeString(Blackhole bh) {
-//        bh.consume(PathUtils.canonicalize(MANY_CHANGE_STRING));
-//    }
-//
-//    @Benchmark
-//    public void directManyChangeString(Blackhole bh) {
-//        bh.consume(PathUtils.directCanonicalize(MANY_CHANGE_STRING));
-//    }
-//
-//    @Benchmark
-//    public void originalManyChangeString(Blackhole bh) {
-//        bh.consume(PathUtilsTest.originalCanonicalize(MANY_CHANGE_STRING));
-//    }
-//
-//    @Benchmark
-//    public void withDotButFine(Blackhole bh) {
-//        bh.consume(PathUtils.canonicalize(WITH_DOT_BUT_FINE));
-//    }
-//
-//
-//    @Benchmark
-//    public void directWithDotButFine(Blackhole bh) {
-//        bh.consume(PathUtils.directCanonicalize(WITH_DOT_BUT_FINE));
-//    }
-//
-//    @Benchmark
-//    public void originalWithDotButFine(Blackhole bh) {
-//        bh.consume(PathUtilsTest.originalCanonicalize(WITH_DOT_BUT_FINE));
-//    }
-//
-//    @Benchmark
-//    public void longWorstCase(Blackhole bh) {
-//        bh.consume(PathUtils.canonicalize(LONG_STRING_WORST_CASE_CONTAINS));
-//    }
-//
-//    @Benchmark
-//    public void directLongWorstCase(Blackhole bh) {
-//        bh.consume(PathUtils.directCanonicalize(LONG_STRING_WORST_CASE_CONTAINS));
-//    }
-//
-//    @Benchmark
-//    public void originalLongWorstCase(Blackhole bh) {
-//        bh.consume(PathUtilsTest.originalCanonicalize(LONG_STRING_WORST_CASE_CONTAINS));
-//    }
+    @Benchmark
+    public void noChangeString(Blackhole bh) {
+        bh.consume(PathUtils.canonicalize(NO_CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void directNoChangeString(Blackhole bh) {
+        bh.consume(PathUtils.directCanonicalize(NO_CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void originalNoChangeString(Blackhole bh) {
+        bh.consume(PathUtilsTest.originalCanonicalize(NO_CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void changeString(Blackhole bh) {
+        bh.consume(PathUtils.canonicalize(CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void directChangeString(Blackhole bh) {
+        bh.consume(PathUtils.directCanonicalize(CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void originalChangeString(Blackhole bh) {
+        bh.consume(PathUtilsTest.originalCanonicalize(CHANGE_STRING));
+    }
+
+
+    @Benchmark
+    public void manyChangeString(Blackhole bh) {
+        bh.consume(PathUtils.canonicalize(MANY_CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void directManyChangeString(Blackhole bh) {
+        bh.consume(PathUtils.directCanonicalize(MANY_CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void originalManyChangeString(Blackhole bh) {
+        bh.consume(PathUtilsTest.originalCanonicalize(MANY_CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void withDotButFine(Blackhole bh) {
+        bh.consume(PathUtils.canonicalize(WITH_DOT_BUT_FINE));
+    }
+
+
+    @Benchmark
+    public void directWithDotButFine(Blackhole bh) {
+        bh.consume(PathUtils.directCanonicalize(WITH_DOT_BUT_FINE));
+    }
+
+    @Benchmark
+    public void originalWithDotButFine(Blackhole bh) {
+        bh.consume(PathUtilsTest.originalCanonicalize(WITH_DOT_BUT_FINE));
+    }
+
+    @Benchmark
+    public void longWorstCase(Blackhole bh) {
+        bh.consume(PathUtils.canonicalize(LONG_STRING_WORST_CASE_CONTAINS));
+    }
+
+    @Benchmark
+    public void directLongWorstCase(Blackhole bh) {
+        bh.consume(PathUtils.directCanonicalize(LONG_STRING_WORST_CASE_CONTAINS));
+    }
+
+    @Benchmark
+    public void originalLongWorstCase(Blackhole bh) {
+        bh.consume(PathUtilsTest.originalCanonicalize(LONG_STRING_WORST_CASE_CONTAINS));
+    }
 
     @Benchmark
     public void longNoChangeCase(Blackhole bh) {

--- a/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
+++ b/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
@@ -1,0 +1,80 @@
+package org.jboss.modules;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.concurrent.TimeUnit;
+
+//@Ignore
+public class PathUtilsBenchmarkTest {
+
+    /**
+     *  This string will not be changed by the canonicalization process
+     */
+    private static final String NO_CHANGE_STRING = "/this/path/has/no/need/to/be/canonicalized";
+
+    /**
+     * This string will be changed by the canonicalization process
+     */
+    private static final String CHANGE_STRING = "/this/./path/has/a/../need/to/be/canonicalized";
+
+    /**
+     * This string will be changed a lot by the canonicalization process
+     */
+    private static final String MANY_CHANGE_STRING = "/../../../../../.././.thing/../../././../";
+
+    @Test
+    public void launch() throws RunnerException {
+        Options opt = new OptionsBuilder()
+            .include(this.getClass().getName() + ".*")
+            .mode(Mode.AverageTime)
+            .timeout(TimeValue.seconds(5))
+            .timeUnit(TimeUnit.MICROSECONDS)
+            .forks(1)
+            .warmupIterations(1)
+            .measurementIterations(4)
+            .shouldDoGC(true)
+            .shouldFailOnError(true)
+            .build();
+
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public void noChangeString(Blackhole bh) {
+        bh.consume(PathUtils.canonicalize(NO_CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void changeString(Blackhole bh) {
+        bh.consume(PathUtils.canonicalize(CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void manyChangeString(Blackhole bh) {
+        bh.consume(PathUtils.canonicalize(MANY_CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void directNoChangeString(Blackhole bh) {
+        bh.consume(PathUtils.directCanonicalize(NO_CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void directChangeString(Blackhole bh) {
+        bh.consume(PathUtils.directCanonicalize(CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void directManyChangeString(Blackhole bh) {
+        bh.consume(PathUtils.directCanonicalize(MANY_CHANGE_STRING));
+    }
+}

--- a/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
+++ b/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
@@ -11,6 +11,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 //@Ignore
@@ -30,6 +31,11 @@ public class PathUtilsBenchmarkTest {
      * This string will be changed a lot by the canonicalization process
      */
     private static final String MANY_CHANGE_STRING = "/../../../../../.././.thing/../../././../";
+
+    /**
+     * Represents a path with just a dot but no need to canonicalize
+     */
+    private static final String WITH_DOT_BUT_FINE = "META-INF/application.properties";
 
     @Test
     public void launch() throws RunnerException {
@@ -64,6 +70,11 @@ public class PathUtilsBenchmarkTest {
     }
 
     @Benchmark
+    public void withDotButFine(Blackhole bh) {
+        bh.consume(PathUtils.canonicalize(WITH_DOT_BUT_FINE));
+    }
+
+    @Benchmark
     public void directNoChangeString(Blackhole bh) {
         bh.consume(PathUtils.directCanonicalize(NO_CHANGE_STRING));
     }
@@ -76,5 +87,10 @@ public class PathUtilsBenchmarkTest {
     @Benchmark
     public void directManyChangeString(Blackhole bh) {
         bh.consume(PathUtils.directCanonicalize(MANY_CHANGE_STRING));
+    }
+
+    @Benchmark
+    public void directWithDotButFine(Blackhole bh) {
+        bh.consume(PathUtils.directCanonicalize(WITH_DOT_BUT_FINE));
     }
 }

--- a/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
+++ b/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
@@ -54,7 +54,7 @@ public class PathUtilsBenchmarkTest {
             .timeout(TimeValue.seconds(30))
             .timeUnit(TimeUnit.MICROSECONDS)
             .forks(1)
-            .threads(4)
+            .threads(8)
             .addProfiler(GCProfiler.class)
             .warmupIterations(2)
             .measurementIterations(5)

--- a/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
+++ b/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.profile.JavaFlightRecorderProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -24,7 +25,7 @@ public class PathUtilsBenchmarkTest {
             .timeout(TimeValue.seconds(30))
             .timeUnit(TimeUnit.MICROSECONDS)
             .forks(1)
-            .threads(2)
+            .threads(4) // original issues were found with EAP's MSC using 4 threads
             .addProfiler(GCProfiler.class)
             .warmupIterations(2)
             .measurementIterations(5)
@@ -56,6 +57,7 @@ public class PathUtilsBenchmarkTest {
             // these strings will be changed a lot by the canonicalization process
             "/../../../../../.././.thing/../../././../",
             "./../../../../..//////.course/../../././../",
+            "./../../../../..//////.course/../../././../com/thing/solution/model/AnotherModel.class",
             // these strings are more representative of the types of strings found in applications and should be represented heavily in the benchmark
             "META-INF/application.properties",
             "com/thing/solution/model/SomeModel.class",

--- a/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
+++ b/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
@@ -27,6 +27,7 @@ public class PathUtilsBenchmarkTest {
             .forks(1)
             .threads(4) // original issues were found with EAP's MSC using 4 threads
             .addProfiler(GCProfiler.class)
+            .addProfiler(JavaFlightRecorderProfiler.class, "dir=target/jfr;configName=profile")
             .warmupIterations(2)
             .measurementIterations(5)
             .shouldDoGC(true)

--- a/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
+++ b/src/test/java/org/jboss/modules/PathUtilsBenchmarkTest.java
@@ -1,17 +1,16 @@
 package org.jboss.modules;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
-import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 //@Ignore
@@ -37,16 +36,28 @@ public class PathUtilsBenchmarkTest {
      */
     private static final String WITH_DOT_BUT_FINE = "META-INF/application.properties";
 
+    /**
+     * This is a long worst case that has a need for canonicalization but pattern matches at the end.
+     */
+    private static final String LONG_STRING_WORST_CASE_CONTAINS = "META-INF/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/.";
+
+    /**
+     * This is a long worst case that does not need canonicalization but _does_ get through the pre-check.
+     */
+    private static final String LONG_STRING_NO_CHANGE = "META-INF/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/.hidden";
+
     @Test
     public void launch() throws RunnerException {
-        Options opt = new OptionsBuilder()
+        final Options opt = new OptionsBuilder()
             .include(this.getClass().getName() + ".*")
             .mode(Mode.AverageTime)
-            .timeout(TimeValue.seconds(5))
+            .timeout(TimeValue.seconds(30))
             .timeUnit(TimeUnit.MICROSECONDS)
             .forks(1)
-            .warmupIterations(1)
-            .measurementIterations(4)
+            .threads(4)
+            .addProfiler(GCProfiler.class)
+            .warmupIterations(2)
+            .measurementIterations(5)
             .shouldDoGC(true)
             .shouldFailOnError(true)
             .build();
@@ -54,43 +65,96 @@ public class PathUtilsBenchmarkTest {
         new Runner(opt).run();
     }
 
+//    @Benchmark
+//    public void noChangeString(Blackhole bh) {
+//        bh.consume(PathUtils.canonicalize(NO_CHANGE_STRING));
+//    }
+//
+//    @Benchmark
+//    public void directNoChangeString(Blackhole bh) {
+//        bh.consume(PathUtils.directCanonicalize(NO_CHANGE_STRING));
+//    }
+//
+//    @Benchmark
+//    public void originalNoChangeString(Blackhole bh) {
+//        bh.consume(PathUtilsTest.originalCanonicalize(NO_CHANGE_STRING));
+//    }
+//
+//    @Benchmark
+//    public void changeString(Blackhole bh) {
+//        bh.consume(PathUtils.canonicalize(CHANGE_STRING));
+//    }
+//
+//    @Benchmark
+//    public void directChangeString(Blackhole bh) {
+//        bh.consume(PathUtils.directCanonicalize(CHANGE_STRING));
+//    }
+//
+//    @Benchmark
+//    public void originalChangeString(Blackhole bh) {
+//        bh.consume(PathUtilsTest.originalCanonicalize(CHANGE_STRING));
+//    }
+//
+//
+//    @Benchmark
+//    public void manyChangeString(Blackhole bh) {
+//        bh.consume(PathUtils.canonicalize(MANY_CHANGE_STRING));
+//    }
+//
+//    @Benchmark
+//    public void directManyChangeString(Blackhole bh) {
+//        bh.consume(PathUtils.directCanonicalize(MANY_CHANGE_STRING));
+//    }
+//
+//    @Benchmark
+//    public void originalManyChangeString(Blackhole bh) {
+//        bh.consume(PathUtilsTest.originalCanonicalize(MANY_CHANGE_STRING));
+//    }
+//
+//    @Benchmark
+//    public void withDotButFine(Blackhole bh) {
+//        bh.consume(PathUtils.canonicalize(WITH_DOT_BUT_FINE));
+//    }
+//
+//
+//    @Benchmark
+//    public void directWithDotButFine(Blackhole bh) {
+//        bh.consume(PathUtils.directCanonicalize(WITH_DOT_BUT_FINE));
+//    }
+//
+//    @Benchmark
+//    public void originalWithDotButFine(Blackhole bh) {
+//        bh.consume(PathUtilsTest.originalCanonicalize(WITH_DOT_BUT_FINE));
+//    }
+//
+//    @Benchmark
+//    public void longWorstCase(Blackhole bh) {
+//        bh.consume(PathUtils.canonicalize(LONG_STRING_WORST_CASE_CONTAINS));
+//    }
+//
+//    @Benchmark
+//    public void directLongWorstCase(Blackhole bh) {
+//        bh.consume(PathUtils.directCanonicalize(LONG_STRING_WORST_CASE_CONTAINS));
+//    }
+//
+//    @Benchmark
+//    public void originalLongWorstCase(Blackhole bh) {
+//        bh.consume(PathUtilsTest.originalCanonicalize(LONG_STRING_WORST_CASE_CONTAINS));
+//    }
+
     @Benchmark
-    public void noChangeString(Blackhole bh) {
-        bh.consume(PathUtils.canonicalize(NO_CHANGE_STRING));
+    public void longNoChangeCase(Blackhole bh) {
+        bh.consume(PathUtils.canonicalize(LONG_STRING_NO_CHANGE));
     }
 
     @Benchmark
-    public void changeString(Blackhole bh) {
-        bh.consume(PathUtils.canonicalize(CHANGE_STRING));
+    public void directLongNoChangeCase(Blackhole bh) {
+        bh.consume(PathUtils.directCanonicalize(LONG_STRING_NO_CHANGE));
     }
 
     @Benchmark
-    public void manyChangeString(Blackhole bh) {
-        bh.consume(PathUtils.canonicalize(MANY_CHANGE_STRING));
+    public void originalLongNoChangeCase(Blackhole bh) {
+        bh.consume(PathUtilsTest.originalCanonicalize(LONG_STRING_NO_CHANGE));
     }
 
-    @Benchmark
-    public void withDotButFine(Blackhole bh) {
-        bh.consume(PathUtils.canonicalize(WITH_DOT_BUT_FINE));
-    }
-
-    @Benchmark
-    public void directNoChangeString(Blackhole bh) {
-        bh.consume(PathUtils.directCanonicalize(NO_CHANGE_STRING));
-    }
-
-    @Benchmark
-    public void directChangeString(Blackhole bh) {
-        bh.consume(PathUtils.directCanonicalize(CHANGE_STRING));
-    }
-
-    @Benchmark
-    public void directManyChangeString(Blackhole bh) {
-        bh.consume(PathUtils.directCanonicalize(MANY_CHANGE_STRING));
-    }
-
-    @Benchmark
-    public void directWithDotButFine(Blackhole bh) {
-        bh.consume(PathUtils.directCanonicalize(WITH_DOT_BUT_FINE));
-    }
 }

--- a/src/test/java/org/jboss/modules/PathUtilsTest.java
+++ b/src/test/java/org/jboss/modules/PathUtilsTest.java
@@ -67,4 +67,27 @@ public class PathUtilsTest {
         assertNull(basicModuleNameToPath("foo//bar"));
         assertNull(basicModuleNameToPath("foo..bar"));
     }
+
+    @Test
+    public void testBufferSize() {
+        assertEquals(MIN_LENGTH, getBuffer(0).length);
+        assertEquals(MIN_LENGTH, getBuffer(1).length);
+        assertEquals(MIN_LENGTH, getBuffer(MIN_LENGTH - 1).length);
+        assertEquals(MIN_LENGTH, getBuffer(MIN_LENGTH).length);
+        assertEquals(MIN_LENGTH * 2, getBuffer(MIN_LENGTH + 1).length);
+        assertEquals(MIN_LENGTH * 4, getBuffer(MIN_LENGTH * 3 + 1).length);
+    }
+
+    // ensure that buffer sharing doesn't cause issues for different path lengths by
+    // running a test that recycles the same buffer in the same thread
+    @Test
+    public void testReusedBuffer() {
+        for(int i = 0; i < 100; i++) {
+            assertEquals("/foo/bar", PathUtils.canonicalize("/foo/bar"));
+            assertEquals("/bar", PathUtils.canonicalize("/foo/../bar"));
+            assertEquals("/", PathUtils.canonicalize("/bar/.."));
+            assertEquals("/baz/", PathUtils.canonicalize("/baz/./"));
+            assertEquals("/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz", PathUtils.canonicalize("/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz"));
+        }
+    }
 }

--- a/src/test/java/org/jboss/modules/PathUtilsTest.java
+++ b/src/test/java/org/jboss/modules/PathUtilsTest.java
@@ -22,6 +22,8 @@ import static org.jboss.modules.PathUtils.*;
 
 import org.junit.Test;
 
+import java.io.File;
+
 import static org.junit.Assert.*;
 
 /**
@@ -30,6 +32,90 @@ import static org.junit.Assert.*;
  * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public class PathUtilsTest {
+
+    /**
+     * Canonicalize the given path.  Removes all {@code .} and {@code ..} segments from the path.
+     *
+     * This is the original code, preserved here to test for correctness.
+     *
+     * @param path the relative or absolute possibly non-canonical path
+     * @return the canonical path
+     */
+    static String originalCanonicalize(String path) {
+        final int length = path.length();
+        // 0 - start
+        // 1 - got one .
+        // 2 - got two .
+        // 3 - got /
+        int state = 0;
+        if (length == 0) {
+            return path;
+        }
+        final char[] targetBuf = new char[length];
+        // string segment end exclusive
+        int e = length;
+        // string cursor position
+        int i = length;
+        // buffer cursor position
+        int a = length - 1;
+        // number of segments to skip
+        int skip = 0;
+        loop: while (--i >= 0) {
+            char c = path.charAt(i);
+            outer: switch (c) {
+                case '/': {
+                    inner: switch (state) {
+                        case 0: state = 3; e = i; break outer;
+                        case 1: state = 3; e = i; break outer;
+                        case 2: state = 3; e = i; skip ++; break outer;
+                        case 3: e = i; break outer;
+                        default: throw new IllegalStateException();
+                    }
+                    // not reached!
+                }
+                case '.': {
+                    inner: switch (state) {
+                        case 0: state = 1; break outer;
+                        case 1: state = 2; break outer;
+                        case 2: break inner; // emit!
+                        case 3: state = 1; break outer;
+                        default: throw new IllegalStateException();
+                    }
+                    // fall thru
+                }
+                default: {
+                    if (File.separatorChar != '/' && c == File.separatorChar) {
+                        switch (state) {
+                            case 0: state = 3; e = i; break outer;
+                            case 1: state = 3; e = i; break outer;
+                            case 2: state = 3; e = i; skip ++; break outer;
+                            case 3: e = i; break outer;
+                            default: throw new IllegalStateException();
+                        }
+                        // not reached!
+                    }
+                    final int newE = e > 0 ? path.lastIndexOf('/', e - 1) : -1;
+                    final int segmentLength = e - newE - 1;
+                    if (skip > 0) {
+                        skip--;
+                    } else {
+                        if (state == 3) {
+                            targetBuf[a--] = '/';
+                        }
+                        path.getChars(newE + 1, e, targetBuf, (a -= segmentLength) + 1);
+                    }
+                    state = 0;
+                    i = newE + 1;
+                    e = newE;
+                    break;
+                }
+            }
+        }
+        if (state == 3) {
+            targetBuf[a--] = '/';
+        }
+        return new String(targetBuf, a + 1, length - a - 1);
+    }
 
     @Test
     public void testIsChild() {
@@ -70,6 +156,10 @@ public class PathUtilsTest {
 
     @Test
     public void testBufferSize() {
+        // remove the current buffer size or this math won't work since
+        // the buffer would be already initialized
+        CHAR_BUFFER_CACHE.remove();
+
         assertEquals(MIN_LENGTH, getBuffer(0).length);
         assertEquals(MIN_LENGTH, getBuffer(1).length);
         assertEquals(MIN_LENGTH, getBuffer(MIN_LENGTH - 1).length);
@@ -79,15 +169,18 @@ public class PathUtilsTest {
     }
 
     // ensure that buffer sharing doesn't cause issues for different path lengths by
-    // running a test that recycles the same buffer in the same thread
+    // running a test that recycles the same buffer in the same thread. this test uses
+    // increasing and decreasing string lengths to ensure that no unintended data makes it
+    // in the string
     @Test
     public void testReusedBuffer() {
         for(int i = 0; i < 100; i++) {
-            assertEquals("/foo/bar", PathUtils.canonicalize("/foo/bar"));
-            assertEquals("/bar", PathUtils.canonicalize("/foo/../bar"));
-            assertEquals("/", PathUtils.canonicalize("/bar/.."));
-            assertEquals("/baz/", PathUtils.canonicalize("/baz/./"));
-            assertEquals("/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz", PathUtils.canonicalize("/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz"));
+            assertEquals(originalCanonicalize("/foo/bar"), PathUtils.canonicalize("/foo/bar"));
+            assertEquals(originalCanonicalize("/foo/../bar"), PathUtils.canonicalize("/foo/../bar"));
+            assertEquals(originalCanonicalize("/bar/.."), PathUtils.canonicalize("/bar/.."));
+            assertEquals(originalCanonicalize("META-INF/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/."), PathUtils.canonicalize("META-INF/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/."));
+            assertEquals(originalCanonicalize("/baz/./"), PathUtils.canonicalize("/baz/./"));
+            assertEquals(originalCanonicalize("/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz"), PathUtils.canonicalize("/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz"));
         }
     }
 }

--- a/src/test/java/org/jboss/modules/PathUtilsTest.java
+++ b/src/test/java/org/jboss/modules/PathUtilsTest.java
@@ -168,30 +168,63 @@ public class PathUtilsTest {
         assertEquals(MIN_LENGTH * 4, getBuffer(MIN_LENGTH * 3 + 1).length);
     }
 
+    private void crosscheck(final String path) {
+        assertEquals(originalCanonicalize(path), canonicalize(path));
+    }
+    
     // ensure that buffer sharing doesn't cause issues for different path lengths by
     // running a test that recycles the same buffer in the same thread. this test uses
     // increasing and decreasing string lengths to ensure that no unintended data makes it
     // in the string
     @Test
-    public void testCorrectAgainstOriginal() {
-        assertEquals(originalCanonicalize(".."), PathUtils.canonicalize(".."));
-        assertEquals(originalCanonicalize("."), PathUtils.canonicalize("."));
-        assertEquals(originalCanonicalize("/foo/bar"), PathUtils.canonicalize("/foo/bar"));
-        assertEquals(originalCanonicalize("/foo/../bar"), PathUtils.canonicalize("/foo/../bar"));
-        assertEquals(originalCanonicalize("/bar/.."), PathUtils.canonicalize("/bar/.."));
-        assertEquals(originalCanonicalize("META-INF/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/."), PathUtils.canonicalize("META-INF/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/."));
-        assertEquals(originalCanonicalize("/baz/./"), PathUtils.canonicalize("/baz/./"));
-        assertEquals(originalCanonicalize("/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz"), PathUtils.canonicalize("/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz"));
-        assertEquals(originalCanonicalize("/baz/hidden.properties/.."), PathUtils.canonicalize("/baz/hidden.properties/.."));
-        assertEquals(originalCanonicalize("/baz/./hidden.properties/../../../check..thing/./"), PathUtils.canonicalize("/baz/./hidden.properties/../../../check..thing/./"));
-    }
+    public void testCurrentAgainstOriginal() {
+        crosscheck("application.properties");
+        crosscheck("./application.properties");
+        crosscheck("/../../../../../../../../other");
+        crosscheck("../../../../../../../../other");
+        crosscheck("../../../../../..");
+        crosscheck("/../../../../../..");
+        crosscheck("/../../..///.///../../..");
+        crosscheck("/thing/../other/../../..");
+        crosscheck("/thing/../other/..");
+        crosscheck("/thing/../other/again/..");
+        crosscheck("thing/../other/../../..");
+        crosscheck("/");
+        crosscheck("//");
+        crosscheck("///////////////////////////////////////////////////////////////////////////////////");
+        crosscheck("..");
+        crosscheck("../");
+        crosscheck("./");
+        crosscheck("/..");
+        crosscheck("/../");
+        crosscheck(".");
+        crosscheck("/./");
+        crosscheck("C:\\windows\\..\\");
+        crosscheck("/foo/bar");
+        crosscheck("/foo/bar///");
+        crosscheck("/foo/../bar");
+        crosscheck("/foo//../bar");
+        crosscheck("//");
+        crosscheck("///./../.././///application.thing/application.properties/..hidden");
+        crosscheck("/bar/..");
+        crosscheck("META-INF/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/.");
+        crosscheck("/baz/./");
+        crosscheck("/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz");
+        crosscheck("/baz/hidden.properties/..");
+        crosscheck("/baz/./hidden.properties/../../../check..thing/./");
 
+        // it might be overkill because some strings are re-used but crosscheck everything in the benchmark plan as well
+        final PathUtilsBenchmarkTest.Plan plan = new PathUtilsBenchmarkTest.Plan();
+        for(final String input : plan.inputs) {
+            crosscheck(input);
+        }
+    }
 
     // run the correctness test over and over to ensure that the buffer reuse doesn't cause issues
     @Test
     public void testReusedBuffer() {
         for(int i = 0; i < 100; i++) {
-            this.testCorrectAgainstOriginal();
+            this.testCurrentAgainstOriginal();
         }
     }
 }

--- a/src/test/java/org/jboss/modules/PathUtilsTest.java
+++ b/src/test/java/org/jboss/modules/PathUtilsTest.java
@@ -173,14 +173,25 @@ public class PathUtilsTest {
     // increasing and decreasing string lengths to ensure that no unintended data makes it
     // in the string
     @Test
+    public void testCorrectAgainstOriginal() {
+        assertEquals(originalCanonicalize(".."), PathUtils.canonicalize(".."));
+        assertEquals(originalCanonicalize("."), PathUtils.canonicalize("."));
+        assertEquals(originalCanonicalize("/foo/bar"), PathUtils.canonicalize("/foo/bar"));
+        assertEquals(originalCanonicalize("/foo/../bar"), PathUtils.canonicalize("/foo/../bar"));
+        assertEquals(originalCanonicalize("/bar/.."), PathUtils.canonicalize("/bar/.."));
+        assertEquals(originalCanonicalize("META-INF/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/."), PathUtils.canonicalize("META-INF/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/."));
+        assertEquals(originalCanonicalize("/baz/./"), PathUtils.canonicalize("/baz/./"));
+        assertEquals(originalCanonicalize("/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz"), PathUtils.canonicalize("/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz"));
+        assertEquals(originalCanonicalize("/baz/hidden.properties/.."), PathUtils.canonicalize("/baz/hidden.properties/.."));
+        assertEquals(originalCanonicalize("/baz/./hidden.properties/../../../check..thing/./"), PathUtils.canonicalize("/baz/./hidden.properties/../../../check..thing/./"));
+    }
+
+
+    // run the correctness test over and over to ensure that the buffer reuse doesn't cause issues
+    @Test
     public void testReusedBuffer() {
         for(int i = 0; i < 100; i++) {
-            assertEquals(originalCanonicalize("/foo/bar"), PathUtils.canonicalize("/foo/bar"));
-            assertEquals(originalCanonicalize("/foo/../bar"), PathUtils.canonicalize("/foo/../bar"));
-            assertEquals(originalCanonicalize("/bar/.."), PathUtils.canonicalize("/bar/.."));
-            assertEquals(originalCanonicalize("META-INF/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/."), PathUtils.canonicalize("META-INF/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/."));
-            assertEquals(originalCanonicalize("/baz/./"), PathUtils.canonicalize("/baz/./"));
-            assertEquals(originalCanonicalize("/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz"), PathUtils.canonicalize("/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz/baz"));
+            this.testCorrectAgainstOriginal();
         }
     }
 }


### PR DESCRIPTION
With EAP 7.2.9 we ran into an issue with having a lot of GC during startup. This PR adds a few strategies to reduce allocations during canonicalizing paths in response to issues with large deployments.

Before:
![image](https://user-images.githubusercontent.com/2073493/222303766-dfe62011-2d72-4881-ba0c-542f1edf837f.png)

After:
![image](https://user-images.githubusercontent.com/2073493/222303723-221fb2c2-5a98-4e96-94d0-02b0ea3bd1f0.png)

As you can see, prior to the change, there were something like 250k allocations. After the change there were seeing closer to 50k. On another instance we were seeing around 65k allocations before and now see around 34k.

While these changes didn't have the affect we were hoping for on startup times we do see a lot less heap pressure and GC events during startup.

I am not sure if this implementation is 100% correct. I'm also not sure that reusing the buffers is required. The most impact seemed to come from just inserting more cases where we know we don't need to do further canonicalization. What I do know is that this is an issue for some small subset of deployments.