### PR TITLE
MODULES-446 Print warnings when an overlay directory structure is unreadable

### DIFF
--- a/src/main/java/org/jboss/modules/LayeredModulePathFactory.java
+++ b/src/main/java/org/jboss/modules/LayeredModulePathFactory.java
@@ -195,11 +195,20 @@ class LayeredModulePathFactory {
 
         final File overlays = new File(layeringRoot, OVERLAYS);
         if (overlays.exists()) {
+            if (!overlays.canRead()) {
+                Module.getModuleLogger().overlaysDirectoryNotReadable(overlays);
+            }
             final File refs = new File(overlays, OVERLAYS);
             if (refs.exists()) {
+                if (!refs.canRead()) {
+                    Module.getModuleLogger().overlaysMetadataNotReadable(overlays);
+                }
                 try {
                     for (final String overlay : readRefs(refs)) {
                         final File root = new File(overlays, overlay);
+                        if (!root.exists() || !root.canRead()) {
+                            Module.getModuleLogger().overlayRootNotReadable(overlays);
+                        }
                         path.add(root);
                     }
                 } catch (IOException e) {

--- a/src/main/java/org/jboss/modules/log/JDKModuleLogger.java
+++ b/src/main/java/org/jboss/modules/log/JDKModuleLogger.java
@@ -18,6 +18,7 @@
 
 package org.jboss.modules.log;
 
+import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -191,6 +192,27 @@ public final class JDKModuleLogger implements ModuleLogger {
     public void classDefined(final String name, final Module module) {
         if (defineLogger.isLoggable(TRACE)) {
             doLog(defineLogger, TRACE, String.format("Defined class %s in %s", name, module), null);
+        }
+    }
+
+    @Override
+    public void overlaysDirectoryNotReadable(File file) {
+        if (logger.isLoggable(WARN)) {
+            doLog(logger, WARN, String.format("Overlays directory exists but is not readable: %s", file.getPath()), null);
+        }
+    }
+
+    @Override
+    public void overlaysMetadataNotReadable(File file) {
+        if (logger.isLoggable(WARN)) {
+            doLog(logger, WARN, String.format("Overlays metadata file exists but is not readable: %s", file.getPath()), null);
+        }
+    }
+
+    @Override
+    public void overlayRootNotReadable(File file) {
+        if (logger.isLoggable(WARN)) {
+            doLog(logger, WARN, String.format("Overlay root directory doesn't exists or is not readable: %s", file.getPath()), null);
         }
     }
 }

--- a/src/main/java/org/jboss/modules/log/ModuleLogger.java
+++ b/src/main/java/org/jboss/modules/log/ModuleLogger.java
@@ -18,6 +18,8 @@
 
 package org.jboss.modules.log;
 
+import java.io.File;
+
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
@@ -63,4 +65,10 @@ public interface ModuleLogger {
     void classDefineFailed(Throwable throwable, String className, Module module);
 
     void classDefined(String name, Module module);
+
+    void overlaysDirectoryNotReadable(File file);
+
+    void overlaysMetadataNotReadable(File file);
+
+    void overlayRootNotReadable(File file);
 }

--- a/src/main/java/org/jboss/modules/log/NoopModuleLogger.java
+++ b/src/main/java/org/jboss/modules/log/NoopModuleLogger.java
@@ -18,6 +18,9 @@
 
 package org.jboss.modules.log;
 
+import java.io.File;
+import java.net.URL;
+
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleLoader;
 
@@ -89,5 +92,17 @@ public final class NoopModuleLogger implements ModuleLogger {
 
     @Override
     public void classDefined(final String name, final Module module) {
+    }
+
+    @Override
+    public void overlaysDirectoryNotReadable(File file) {
+    }
+
+    @Override
+    public void overlaysMetadataNotReadable(File file) {
+    }
+
+    @Override
+    public void overlayRootNotReadable(File file) {
     }
 }

--- a/src/main/java/org/jboss/modules/log/StreamModuleLogger.java
+++ b/src/main/java/org/jboss/modules/log/StreamModuleLogger.java
@@ -18,6 +18,7 @@
 
 package org.jboss.modules.log;
 
+import java.io.File;
 import java.io.OutputStream;
 import java.io.PrintStream;
 
@@ -152,5 +153,17 @@ public final class StreamModuleLogger implements ModuleLogger {
     }
 
     public void classDefined(final String name, final Module module) {
+    }
+
+    @Override
+    public void overlaysDirectoryNotReadable(File file) {
+    }
+
+    @Override
+    public void overlaysMetadataNotReadable(File file) {
+    }
+
+    @Override
+    public void overlayRootNotReadable(File file) {
     }
 }

--- a/src/test/java/org/jboss/modules/LayeredModulePathFactoryTest.java
+++ b/src/test/java/org/jboss/modules/LayeredModulePathFactoryTest.java
@@ -1,0 +1,204 @@
+package org.jboss.modules;
+
+import org.jboss.modules.log.ModuleLogger;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class LayeredModulePathFactoryTest {
+
+    private static final String OVERLAYS = ".overlays";
+    private static final String OVERLAY_NAME = "overlay-1";
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private File layeringRoot;
+    private File overlaysDir;
+    private File metadataFile;
+    private File overlayRoot;
+    private final List<File> discoveredPaths = new ArrayList<>();
+
+    private boolean overlaysDirNotReadableLogged = false;
+    private boolean overlaysMetadataNotReadableLogged = false;
+    private boolean overlayRootNotReadableLogged = false;
+
+    @Before
+    public void setup() throws IOException {
+        boolean isPosix = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+        Assume.assumeTrue("This test requires POSIX compatible OS", isPosix);
+
+        layeringRoot = temporaryFolder.getRoot();
+
+        // layeringRoot/.overlays/
+        overlaysDir = new File(layeringRoot, OVERLAYS);
+        Assert.assertTrue(overlaysDir.mkdir());
+
+        // layeringRoot/.overlays/.overlays file
+        metadataFile = new File(overlaysDir, OVERLAYS);
+        Assert.assertTrue(metadataFile.createNewFile());
+        writeRefsFile(metadataFile);
+
+        // layeringRoot/.overlays/overlay-1/
+        overlayRoot = new File(overlaysDir, OVERLAY_NAME);
+        Assert.assertTrue(overlayRoot.mkdir());
+
+        // custom logger to detect warn messages being printed
+        Module.setModuleLogger(new CustomLogger());
+    }
+
+    @Test
+    public void testReadable() {
+        LayeredModulePathFactory.loadOverlays(layeringRoot, discoveredPaths);
+
+        Assert.assertFalse(overlaysDirNotReadableLogged);
+        Assert.assertFalse(overlaysMetadataNotReadableLogged);
+        Assert.assertFalse(overlayRootNotReadableLogged);
+    }
+
+    @Test
+    public void testUnreadableOverlays() throws IOException {
+        // make directory non-readable
+        Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("-w-------");
+        Files.setPosixFilePermissions(overlaysDir.toPath(), permissions);
+
+        LayeredModulePathFactory.loadOverlays(layeringRoot, discoveredPaths);
+
+        Assert.assertTrue(overlaysDirNotReadableLogged);
+        Assert.assertFalse(overlaysMetadataNotReadableLogged);
+        Assert.assertFalse(overlayRootNotReadableLogged);
+    }
+
+    @Test
+    public void testUnreadableOverlaysMetadataFile() throws IOException {
+        // make directory non-readable
+        Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("-w-------");
+        Files.setPosixFilePermissions(metadataFile.toPath(), permissions);
+
+        try {
+            LayeredModulePathFactory.loadOverlays(layeringRoot, discoveredPaths);
+        } catch (RuntimeException e) {
+            // ignore
+        }
+
+        Assert.assertFalse(overlaysDirNotReadableLogged);
+        Assert.assertTrue(overlaysMetadataNotReadableLogged);
+        Assert.assertFalse(overlayRootNotReadableLogged);
+    }
+
+    @Test
+    public void testUnreadableOverlayRoot() throws IOException {
+        // make directory non-readable
+        Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("-w-------");
+        Files.setPosixFilePermissions(overlayRoot.toPath(), permissions);
+
+        LayeredModulePathFactory.loadOverlays(layeringRoot, discoveredPaths);
+
+        Assert.assertFalse(overlaysDirNotReadableLogged);
+        Assert.assertFalse(overlaysMetadataNotReadableLogged);
+        Assert.assertTrue(overlayRootNotReadableLogged);
+    }
+
+    private static void writeRefsFile(File file) throws IOException {
+        Files.write(file.toPath(), (OVERLAY_NAME + '\n').getBytes());
+    }
+
+    /**
+     * This is a custom logger that detects if specific messages has been logged.
+     */
+    private class CustomLogger implements ModuleLogger {
+
+        @Override
+        public void trace(String message) {
+
+        }
+
+        @Override
+        public void trace(String format, Object arg1) {
+
+        }
+
+        @Override
+        public void trace(String format, Object arg1, Object arg2) {
+
+        }
+
+        @Override
+        public void trace(String format, Object arg1, Object arg2, Object arg3) {
+
+        }
+
+        @Override
+        public void trace(String format, Object... args) {
+
+        }
+
+        @Override
+        public void trace(Throwable t, String message) {
+
+        }
+
+        @Override
+        public void trace(Throwable t, String format, Object arg1) {
+
+        }
+
+        @Override
+        public void trace(Throwable t, String format, Object arg1, Object arg2) {
+
+        }
+
+        @Override
+        public void trace(Throwable t, String format, Object arg1, Object arg2, Object arg3) {
+
+        }
+
+        @Override
+        public void trace(Throwable t, String format, Object... args) {
+
+        }
+
+        @Override
+        public void greeting() {
+
+        }
+
+        @Override
+        public void classDefineFailed(Throwable throwable, String className, Module module) {
+
+        }
+
+        @Override
+        public void classDefined(String name, Module module) {
+
+        }
+
+        @Override
+        public void overlaysDirectoryNotReadable(File file) {
+            overlaysDirNotReadableLogged = true;
+        }
+
+        @Override
+        public void overlaysMetadataNotReadable(File file) {
+            overlaysMetadataNotReadableLogged = true;
+        }
+
+        @Override
+        public void overlayRootNotReadable(File file) {
+            overlayRootNotReadableLogged = true;
+        }
+    }
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-26674
Upstream issue: https://issues.redhat.com/browse/MODULES-446
No upstream needed (this is the upstream branch)