### PR TITLE
[MODULES-446] Fixing tests - ensure proper test cleanups

### DIFF
--- a/src/test/java/org/jboss/modules/LayeredModulePathFactoryTest.java
+++ b/src/test/java/org/jboss/modules/LayeredModulePathFactoryTest.java
@@ -72,10 +72,15 @@ public class LayeredModulePathFactoryTest {
     @Test
     public void testUnreadableOverlays() throws IOException {
         // make directory non-readable
-        Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("-w-------");
-        Files.setPosixFilePermissions(overlaysDir.toPath(), permissions);
+        Set<PosixFilePermission> origPermissions = Files.getPosixFilePermissions(overlaysDir.toPath());
+        try {
+            Set<PosixFilePermission> testPermissions = PosixFilePermissions.fromString("-w-------");
+            Files.setPosixFilePermissions(overlaysDir.toPath(), testPermissions);
 
-        LayeredModulePathFactory.loadOverlays(layeringRoot, discoveredPaths);
+            LayeredModulePathFactory.loadOverlays(layeringRoot, discoveredPaths);
+        } finally {
+            Files.setPosixFilePermissions(overlaysDir.toPath(), origPermissions);
+        }
 
         Assert.assertTrue(overlaysDirNotReadableLogged);
         Assert.assertFalse(overlaysMetadataNotReadableLogged);
@@ -85,13 +90,18 @@ public class LayeredModulePathFactoryTest {
     @Test
     public void testUnreadableOverlaysMetadataFile() throws IOException {
         // make directory non-readable
-        Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("-w-------");
-        Files.setPosixFilePermissions(metadataFile.toPath(), permissions);
-
+        Set<PosixFilePermission> origPermissions = Files.getPosixFilePermissions(overlaysDir.toPath());
         try {
-            LayeredModulePathFactory.loadOverlays(layeringRoot, discoveredPaths);
-        } catch (RuntimeException e) {
-            // ignore
+            Set<PosixFilePermission> testPermissions = PosixFilePermissions.fromString("-w-------");
+            Files.setPosixFilePermissions(metadataFile.toPath(), testPermissions);
+
+            try {
+                LayeredModulePathFactory.loadOverlays(layeringRoot, discoveredPaths);
+            } catch (RuntimeException e) {
+                // ignore
+            }
+        } finally {
+            Files.setPosixFilePermissions(overlaysDir.toPath(), origPermissions);
         }
 
         Assert.assertFalse(overlaysDirNotReadableLogged);
@@ -102,10 +112,15 @@ public class LayeredModulePathFactoryTest {
     @Test
     public void testUnreadableOverlayRoot() throws IOException {
         // make directory non-readable
-        Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("-w-------");
-        Files.setPosixFilePermissions(overlayRoot.toPath(), permissions);
+        Set<PosixFilePermission> origPermissions = Files.getPosixFilePermissions(overlaysDir.toPath());
+        try {
+            Set<PosixFilePermission> testPermissions = PosixFilePermissions.fromString("-w-------");
+            Files.setPosixFilePermissions(overlayRoot.toPath(), testPermissions);
 
-        LayeredModulePathFactory.loadOverlays(layeringRoot, discoveredPaths);
+            LayeredModulePathFactory.loadOverlays(layeringRoot, discoveredPaths);
+        } finally {
+            Files.setPosixFilePermissions(overlaysDir.toPath(), origPermissions);
+        }
 
         Assert.assertFalse(overlaysDirNotReadableLogged);
         Assert.assertFalse(overlaysMetadataNotReadableLogged);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-26674
Upstream issue: https://issues.redhat.com/browse/MODULES-446
Follows up on: https://github.com/jboss-modules/jboss-modules/pull/324

Previous version of the test was causing 'maven clean' failures. Detailed error description:

[INFO] --- clean:3.3.2:clean (default-clean) @ jboss-modules ---
[INFO] Deleting /home/opalka/git/redhat/PUBLIC/jboss-modules/target
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.334 s
[INFO] Finished at: 2024-02-21T18:33:45+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-clean-plugin:3.3.2:clean (default-clean) on project jboss-modules: Failed to clean project: Failed to delete /home/opalka/git/redhat/PUBLIC/jboss-modules/target/junit8091973050755464239/.overlays -> [Help 1]
