### PR TITLE
[MODULES-442] Do not discard the cause of linkage errors in ModuleClassLoader.defineClass() method

### DIFF
--- a/src/main/java/org/jboss/modules/ModuleClassLoader.java
+++ b/src/main/java/org/jboss/modules/ModuleClassLoader.java
@@ -489,6 +489,7 @@ public class ModuleClassLoader extends ConcurrentClassLoader {
                     final String oldMsg = e.getMessage();
                     final String newMsg = "Failed to link " + name.replace('.', '/') + " (" + module + ")";
                     ne = e.getClass().getConstructor(String.class).newInstance(oldMsg == null || oldMsg.isEmpty() ? newMsg : newMsg + ": " + oldMsg);
+                    ne.initCause(e.getCause());
                     ne.setStackTrace(e.getStackTrace());
                 } catch (InstantiationException | NoSuchMethodException | InvocationTargetException | IllegalAccessException ignored) {
                     // just throw the original


### PR DESCRIPTION
https://issues.redhat.com/browse/MODULES-442