### PR TITLE
Deprecate `org.jboss.modules.ref`

### DIFF
--- a/src/main/java/org/jboss/modules/ref/PhantomReference.java
+++ b/src/main/java/org/jboss/modules/ref/PhantomReference.java
@@ -30,7 +30,11 @@ import java.lang.ref.ReferenceQueue;
  * @see java.lang.ref.PhantomReference
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ *
+ * @deprecated Use {@link java.lang.ref.Cleaner} or one of the reference types from a support library such as
+ *      {@code io.smallrye.common:smallrye-common-ref} instead.
  */
+@Deprecated
 public class PhantomReference<T, A> extends java.lang.ref.PhantomReference<T> implements Reference<T, A>, Reapable<T, A> {
     private final A attachment;
     private final Reaper<T, A> reaper;

--- a/src/main/java/org/jboss/modules/ref/Reapable.java
+++ b/src/main/java/org/jboss/modules/ref/Reapable.java
@@ -28,6 +28,7 @@ package org.jboss.modules.ref;
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
+@Deprecated
 interface Reapable<T, A> {
 
     /**

--- a/src/main/java/org/jboss/modules/ref/Reaper.java
+++ b/src/main/java/org/jboss/modules/ref/Reaper.java
@@ -25,7 +25,11 @@ package org.jboss.modules.ref;
  * @param <A> the reference attachment type
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ *
+ * @deprecated Use {@link java.lang.ref.Cleaner} or one of the reference types from a support library such as
+ *      {@code io.smallrye.common:smallrye-common-ref} instead.
  */
+@Deprecated
 public interface Reaper<T, A> {
 
     /**

--- a/src/main/java/org/jboss/modules/ref/Reference.java
+++ b/src/main/java/org/jboss/modules/ref/Reference.java
@@ -27,7 +27,11 @@ package org.jboss.modules.ref;
  * @see java.lang.ref.Reference
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ *
+ * @deprecated Use {@link java.lang.ref.Cleaner} or one of the reference types from a support library such as
+ *      {@code io.smallrye.common:smallrye-common-ref} instead.
  */
+@Deprecated
 public interface Reference<T, A> {
 
     /**

--- a/src/main/java/org/jboss/modules/ref/References.java
+++ b/src/main/java/org/jboss/modules/ref/References.java
@@ -22,7 +22,11 @@ import java.lang.ref.ReferenceQueue;
 
 /**
  * A set of utility methods for reference types.
+ *
+ * @deprecated Use {@link java.lang.ref.Cleaner} or one of the reference types from a support library such as
+ *      {@code io.smallrye.common:smallrye-common-ref} instead.
  */
+@Deprecated
 public final class References {
     @SuppressWarnings({ "RawUseOfParameterizedType" })
     private static final Reference NULL = new Reference() {

--- a/src/main/java/org/jboss/modules/ref/SoftReference.java
+++ b/src/main/java/org/jboss/modules/ref/SoftReference.java
@@ -30,7 +30,11 @@ import java.lang.ref.ReferenceQueue;
  * @see java.lang.ref.SoftReference
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ *
+ * @deprecated Use {@link java.lang.ref.Cleaner} or one of the reference types from a support library such as
+ *      {@code io.smallrye.common:smallrye-common-ref} instead.
  */
+@Deprecated
 public class SoftReference<T, A> extends java.lang.ref.SoftReference<T> implements Reference<T, A>, Reapable<T, A> {
     private final A attachment;
     private final Reaper<T, A> reaper;

--- a/src/main/java/org/jboss/modules/ref/StrongReference.java
+++ b/src/main/java/org/jboss/modules/ref/StrongReference.java
@@ -25,7 +25,11 @@ package org.jboss.modules.ref;
  * @param <A> the attachment type
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ *
+ * @deprecated Use {@link java.lang.ref.Cleaner} or one of the reference types from a support library such as
+ *      {@code io.smallrye.common:smallrye-common-ref} instead.
  */
+@Deprecated
 public class StrongReference<T, A> implements Reference<T, A> {
 
     private volatile T value;

--- a/src/main/java/org/jboss/modules/ref/WeakReference.java
+++ b/src/main/java/org/jboss/modules/ref/WeakReference.java
@@ -30,7 +30,11 @@ import java.lang.ref.ReferenceQueue;
  * @see java.lang.ref.WeakReference
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ *
+ * @deprecated Use {@link java.lang.ref.Cleaner} or one of the reference types from a support library such as
+ *      {@code io.smallrye.common:smallrye-common-ref} instead.
  */
+@Deprecated
 public class WeakReference<T, A> extends java.lang.ref.WeakReference<T> implements Reference<T, A>, Reapable<T, A> {
     private final A attachment;
     private final Reaper<T, A> reaper;

--- a/src/main/java/org/jboss/modules/ref/package-info.java
+++ b/src/main/java/org/jboss/modules/ref/package-info.java
@@ -19,5 +19,9 @@
 /**
  * Classes which implement reference types which can be cleaned up automatically by a background thread.  See
  * {@link org.jboss.modules.ref.Reference Reference} and its subtypes, and {@link org.jboss.modules.ref.Reaper Reaper} for more information.
+ *
+ * @deprecated Use {@link java.lang.ref.Cleaner} or one of the reference types from a support library such as
+ *      {@code io.smallrye.common:smallrye-common-ref} instead.
  */
+@Deprecated
 package org.jboss.modules.ref;


### PR DESCRIPTION
There is now `java.lang.ref.Cleaner`, not to mention equivalent functionality in `smallrye-common` and `wildfly-common` to use instead.