### PR TITLE
Avoid leaking thread locals

### DIFF
--- a/src/main/java/org/jboss/modules/ModularURLStreamHandlerFactory.java
+++ b/src/main/java/org/jboss/modules/ModularURLStreamHandlerFactory.java
@@ -115,6 +115,10 @@ final class ModularURLStreamHandlerFactory implements URLStreamHandlerFactory {
                 });
             } finally {
                 set.remove(protocol);
+                if (set.isEmpty()) {
+                    // avoid leaking thread-locals
+                    reentered.remove();
+                }
             }
         }
         return null;


### PR DESCRIPTION
This can be significant when using virtual threads.