### PR TITLE
remove finalizer from ModuleClassLoader

### DIFF
--- a/src/main/java/org/jboss/modules/ModuleClassLoader.java
+++ b/src/main/java/org/jboss/modules/ModuleClassLoader.java
@@ -693,12 +693,6 @@ public class ModuleClassLoader extends ConcurrentClassLoader {
         return super.clone();
     }
 
-    /** {@inheritDoc} */
-    @Override
-    protected final void finalize() throws Throwable {
-        super.finalize();
-    }
-
     ResourceLoader[] getResourceLoaders() {
         final ResourceLoaderSpec[] specs = paths.get().getSourceList(ResourceLoaderSpec.NO_RESOURCE_LOADERS);
         final int length = specs.length;


### PR DESCRIPTION
https://github.com/jboss-modules/jboss-modules/issues/792

https://openjdk.org/jeps/421 deprecated Java finalization but did not remove it.  This pull request is for removing the finalizer.